### PR TITLE
Modified the input data script call.

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -46,8 +46,7 @@ $evalGlobal fBaseY %fStartY% - %fPeriodOfYears%
 *** end of dollar commands section, no further flag definitions allowed 
 
 *** load input data files
-*$call '"C:\Users\gianoussakis\AppData\Local\Programs\R\R-4.3.0\bin\Rscript.exe" ".\loadMadratData.R"'
-*$call '"C:\Users\GIannousakis\AppData\Local\Programs\R\R-4.3.1\bin\Rscript.exe" ".\loadMadratData.R"'
+$call "RScript ./loadMadratData.R"
 
 $include sets.gms
 $include declarations.gms


### PR DESCRIPTION
Notes:

- Removed the RScript executable path, assuming that users will add it to their PATH environment variable, as per our instructions.
- Removed the GAMS comment character, so the R script will be called by default. Let me know if this is desired behavior right now.
- Changed the backslash character to slash, for better compatibility with UNIX-based environments and software, still works fine in Windows.