### PR TITLE
Changed GH Action permissions

### DIFF
--- a/.github/workflows/comment_to_issue.yml
+++ b/.github/workflows/comment_to_issue.yml
@@ -23,4 +23,5 @@ jobs:
         MIN_CHARACTERS: 5
         INCLUDE_PATTERN: "\\.(gms|R)$"
 
-permissions: write-all
+permissions: 
+  issues: write

--- a/main.gms
+++ b/main.gms
@@ -57,3 +57,6 @@ $include solve.gms
 
 * FIXME: This issue will be created after the PR is merged.
 * author=derevirn
+
+* FIXME: Testing GH Action changed permissions.
+* author=derevirn


### PR DESCRIPTION
This GH action automatically utilizes third party code to parse comments and create new issues. Because of this, it's better to have a limited scope of permissions, to avoid any potential security vulnerabilities. 