### PR TITLE
Added custom scenario name functionality

### DIFF
--- a/Tutorials/03_Running OPEN‐PROM.md
+++ b/Tutorials/03_Running OPEN‐PROM.md
@@ -26,6 +26,9 @@ After running this command, you must authorize the Tidyverse API Packages to acc
 ## Setting a Custom GAMS Path
 In some cases, it is beneficial to install multiple versions of GAMS, for testing and debugging purposes. For example, you can execute the model with both GAMS version 45 and 46, and compare the results. To specify the GAMS version that is used while executing the model, you can add the associated directory path to the `"gams_path"` parameter of the configuration file. To avoid errors, please remember to include a trailing slash, e.g. `C:\GAMS\45\`.
 
+## Setting a Custom Scenario Name
+Running various different scenarios is a fundamental aspect of integrated assessment modelling, with the purpose of comparing alternative decarbonization pathways and exploring greenhouse gas emissions trajectories. You can easily specify the scenario name of your preference, by setting the `"scenario_name"` parameter in the configuration file. This scenario name will be used in the model run folders that were mentioned previously.
+
 # Testing the Model with Dummy Data
 As mentioned in Tutorial 02, OPEN-PROM utilizes some proprietary data sources that can't be publicly shared. Regardless of that, you can still run and experiment with the model, even if you don't have access to the aforementioned data. You simply need to download [OPEN-PROM v1.0.0](https://github.com/e3modelling/OPEN-PROM/releases/tag/v1.0.0), and make sure you have recent versions of GAMS and the R language installed on your computer. Afterwards, you simply need to open a terminal window and execute the following command:  
 

--- a/config.template.json
+++ b/config.template.json
@@ -1,4 +1,5 @@
 {
     "model_runs_path": "local\\path\\to\\model\\runs",
-    "gams_path": "path\\to\\gams\\folder\\including\\trailing\\slash\\"
+    "gams_path": "path\\to\\gams\\folder\\including\\trailing\\slash\\",
+    "scenario_name": "SCENARIO"
 }

--- a/config.template.json
+++ b/config.template.json
@@ -1,5 +1,5 @@
 {
     "model_runs_path": "local\\path\\to\\model\\runs",
     "gams_path": "path\\to\\gams\\folder\\including\\trailing\\slash\\",
-    "scenario_name": "SCENARIO"
+    "scenario_name": "SCEN"
 }

--- a/start.R
+++ b/start.R
@@ -124,23 +124,26 @@ uploadToGDrive <- function() {
   
 }
 
-# Function that sets the scenario name
+### Define a function that returns the scenario name
 setScenarioName <- function(scen_default) {
 
+  scen_config <- NULL
   # Reading the scenario name from config file
   if (file.exists('config.json')) {
     config <- fromJSON('config.json')
     scen_config <- config$scenario_name
-
   }
+
   # Checking if the scenario name is NULL or empty string
   if(!is.null(scen_config) && nzchar(trimws(scen_config)) ) {
     scen <- scen_config
   
   } else {
     # If the config scenario name is not valid, get the default one
+    # as specified in each VS Code task, e.g. DEV, DEVNEWDATA etc
+    cat("Invalid scenario name or missing config file, setting default name.\n")
     scen <- scen_default
-    
+
   }
   
   return(scen)
@@ -158,7 +161,7 @@ if (file.exists('config.json')) {
     gams <- paste0(gams_path,'gams')
 
   } else {
-    cat("The specified custom GAMS path is not valid. Using the default path. ")
+    cat("The specified custom GAMS path is not valid. Using the default path.\n")
     gams <- 'gams'
   }
 
@@ -195,7 +198,7 @@ if (!is.null(task) && task == 0) {
 
     # Running task OPEN-PROM DEV NEW DATA
     saveMetadata(DevMode = 1)
-    if(withRunFolder) createRunFolder("DEVNEWDATA")
+    if(withRunFolder) createRunFolder(setScenarioName("DEVNEWDATA"))
 
     shell(paste0(gams,' main.gms --DevMode=1 --GenerateInput=on -logOption 4 -Idir=./data 2>&1 | tee full.log'))
 
@@ -209,7 +212,7 @@ if (!is.null(task) && task == 0) {
     
     # Running task OPEN-PROM RESEARCH
     saveMetadata(DevMode = 0)
-    if(withRunFolder) createRunFolder("RES")
+    if(withRunFolder) createRunFolder(setScenarioName("RES"))
 
     shell(paste0(gams,' main.gms --DevMode=0 --GenerateInput=off -logOption 4 -Idir=./data 2>&1 | tee full.log'))
 
@@ -219,7 +222,7 @@ if (!is.null(task) && task == 0) {
     
     # Running task OPEN-PROM RESEARCH NEW DATA
     saveMetadata(DevMode = 0)
-    if(withRunFolder) createRunFolder("RESNEWDATA")
+    if(withRunFolder) createRunFolder(setScenarioName("RESNEWDATA"))
 
     shell(paste0(gams,' main.gms --DevMode=0 --GenerateInput=on -logOption 4 -Idir=./data 2>&1 | tee full.log'))
 

--- a/start.R
+++ b/start.R
@@ -3,7 +3,7 @@ library(jsonlite)
 
 # Various flags used to modify script behavior
 withRunFolder = TRUE # Set to FALSE to disable model run folder creation and file copying
-withUpload = TRUE # Set to FALSE to disable model run upload to Google Drive
+withUpload = F # Set to FALSE to disable model run upload to Google Drive
 uploadGDX = FALSE # Set to TRUE to include GDX files in the uploaded archive
 
 ### Define function that saves model metadata into a JSON file.
@@ -124,21 +124,43 @@ uploadToGDrive <- function() {
   
 }
 
+# Function that sets the scenario name
+setScenarioName <- function(scen_default) {
+
+  # Reading the scenario name from config file
+  if (file.exists('config.json')) {
+    config <- fromJSON('config.json')
+    scen_config <- config$scenario_name
+
+  }
+  # Checking if the scenario name is NULL or empty string
+  if(!is.null(scen_config) && nzchar(trimws(scen_config)) ) {
+    scen <- scen_config
+  
+  } else {
+    # If the config scenario name is not valid, get the default one
+    scen <- scen_default
+    
+  }
+  
+  return(scen)
+}
+
 ### Executing the VS Code tasks
 
 # Optionally setting a custom GAMS path
 if (file.exists('config.json')) {
-        config <- fromJSON('config.json')
-        gams_path <- config$gams_path
+  config <- fromJSON('config.json')
+  gams_path <- config$gams_path
 
-        # Checking if the specified path exists and is a directory
-        if(!is.null(gams_path) && file.exists(gams_path) && file.info(gams_path)$isdir) {
-          gams <- paste0(gams_path,'gams')
+  # Checking if the specified path exists and is a directory
+  if(!is.null(gams_path) && file.exists(gams_path) && file.info(gams_path)$isdir) {
+    gams <- paste0(gams_path,'gams')
 
-        } else {
-          cat("The specified custom GAMS path is not valid. Using the default path. ")
-          gams <- 'gams'
-        }
+  } else {
+    cat("The specified custom GAMS path is not valid. Using the default path. ")
+    gams <- 'gams'
+  }
 
 } else {
 
@@ -163,7 +185,7 @@ if (!is.null(task) && task == 0) {
 
     # Running task OPEN-PROM DEV
     saveMetadata(DevMode = 1)
-    if(withRunFolder) createRunFolder("DEV")
+    if(withRunFolder) createRunFolder(setScenarioName("DEV"))
 
     shell(paste0(gams,' main.gms --DevMode=1 --GenerateInput=off -logOption 4 -Idir=./data 2>&1 | tee full.log'))
 

--- a/start.R
+++ b/start.R
@@ -3,7 +3,7 @@ library(jsonlite)
 
 # Various flags used to modify script behavior
 withRunFolder = TRUE # Set to FALSE to disable model run folder creation and file copying
-withUpload = F # Set to FALSE to disable model run upload to Google Drive
+withUpload = TRUE # Set to FALSE to disable model run upload to Google Drive
 uploadGDX = FALSE # Set to TRUE to include GDX files in the uploaded archive
 
 ### Define function that saves model metadata into a JSON file.


### PR DESCRIPTION
* The `setScenarioName()` function validates the scenario name from `config.json`, checking for NULL and empty strings.
* In case the scenario name is invalid, the default name of each task is used, e.g. DEV, DEVNEWDATA etc