### PR TITLE
Updated preloop to automatically fix historical values for VNewCapElec

### DIFF
--- a/modules/04_PowerGeneration/legacy/preloop.gms
+++ b/modules/04_PowerGeneration/legacy/preloop.gms
@@ -39,16 +39,10 @@ VCostVarTechElec.L(runCy,PGALL,YTIME) = 0.1;
 *---
 VCostVarTechElecTot.L(runCy,YTIME) = 0.1;
 *---
-VNewCapElec.FX(runCy,PGALL,"2011")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2011")- iInstCapPast(runCy,PGALL,"2010") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2012")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2012")- iInstCapPast(runCy,PGALL,"2011") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2013")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2013")- iInstCapPast(runCy,PGALL,"2012") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2014")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2014")- iInstCapPast(runCy,PGALL,"2013") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2015")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2015")- iInstCapPast(runCy,PGALL,"2014") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2016")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2016")- iInstCapPast(runCy,PGALL,"2015") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2017")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2017")- iInstCapPast(runCy,PGALL,"2016") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2018")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2018")- iInstCapPast(runCy,PGALL,"2017") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2019")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2019")- iInstCapPast(runCy,PGALL,"2018") +1E-10;
-VNewCapElec.FX(runCy,PGALL,"2020")$PGREN(PGALL) = iInstCapPast(runCy,PGALL,"2020")- iInstCapPast(runCy,PGALL,"2019") +1E-10;
+alias(datay, dataylag)
+loop (runCy,PGALL,datay,dataylag)$(ord(datay) = ord(dataylag) + 1 and PGREN(PGALL)) DO
+  VNewCapElec.FX(runCy,PGALL,datay) = iInstCapPast(runCy,PGALL,datay) - iInstCapPast(runCy,PGALL,dataylag)$(ord(dataylag) eq ord(datay)-1) + 1E-10;
+ENDLOOP;
 VNewCapElec.FX(runCy,"PGLHYD",YTIME)$TFIRST(YTIME) = +1E-10;
 *---
 VCFAvgRen.L(runCy,PGALL,YTIME) = 0.1;

--- a/modules/04_PowerGeneration/legacy/preloop.gms
+++ b/modules/04_PowerGeneration/legacy/preloop.gms
@@ -41,7 +41,7 @@ VCostVarTechElecTot.L(runCy,YTIME) = 0.1;
 *---
 alias(datay, dataylag)
 loop (runCy,PGALL,datay,dataylag)$(ord(datay) = ord(dataylag) + 1 and PGREN(PGALL)) DO
-  VNewCapElec.FX(runCy,PGALL,datay) = iInstCapPast(runCy,PGALL,datay) - iInstCapPast(runCy,PGALL,dataylag)$(ord(dataylag) eq ord(datay)-1) + 1E-10;
+  VNewCapElec.FX(runCy,PGALL,datay) = iInstCapPast(runCy,PGALL,datay) - iInstCapPast(runCy,PGALL,dataylag) + 1E-10;
 ENDLOOP;
 VNewCapElec.FX(runCy,"PGLHYD",YTIME)$TFIRST(YTIME) = +1E-10;
 *---


### PR DESCRIPTION
Updated so we can run predictions on historical years, if needed. No changes in the result gdx:
Before:
![image](https://github.com/user-attachments/assets/6fc82925-f7bb-4499-b145-495a6b89940e)
After:
![image](https://github.com/user-attachments/assets/01526784-ac39-4cb3-bfff-98ff5df73c44)

(Changes in PGWIND are a result of updating mrprom capacity estimation for historical data)
