### PR TITLE
Update openprom to postprom

### DIFF
--- a/reportOutput.R
+++ b/reportOutput.R
@@ -1,8 +1,7 @@
 # This script generates a mif file for comparison of OPEN-PROM data with MENA-EDS and ENERDATA
 library(madrat)
-library(openprom)
+library(postprom)
 library(reticulate)
-library(knitr)
 
 installPythonPackages <- function(packages) {
   for (pkg in packages) {


### PR DESCRIPTION
- Changed name of openprom package to postprom
- Check TinyTeX installation before generating PDFs in postprom
