### PR TITLE
Carval

### DIFF
--- a/start.R
+++ b/start.R
@@ -3,7 +3,7 @@ library(jsonlite)
 
 # Various flags used to modify script behavior
 withRunFolder <- TRUE # Set to FALSE to disable model run folder creation and file copying
-withSync <- FALSE # Set to FALSE to disable model run sync to SharePoint
+withSync <- TRUE # Set to FALSE to disable model run sync to SharePoint
 withReport <- TRUE # Set to FALSE to disable the report output script execution (applicable to research mode only)
 uploadGDX <- TRUE # Set to TRUE to include GDX files in the uploaded archive
 


### PR DESCRIPTION
Removing the double counting of carbon value in PG.

Double counting appeared only in PG. The testing below:

<img width="1242" height="645" alt="Image" src="https://github.com/user-attachments/assets/4591d0a4-f346-4ded-a85e-58f234bce0e2" />

<img width="1227" height="667" alt="Image" src="https://github.com/user-attachments/assets/11d0ff4e-a0d1-4e5d-ac16-832e26944981" />

<img width="1225" height="656" alt="Image" src="https://github.com/user-attachments/assets/a24ccb33-e70b-4dbc-9694-f2cceb7b99b4" />

Also indicatively, the mixture in sec energy in 2c
<img width="1211" height="665" alt="image" src="https://github.com/user-attachments/assets/83ede2d3-f38c-4a55-b605-08c6664fb704" />
