### PR TITLE
Update and fix Github action for documentation

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron: '0 0 1 * *'   # Monthly schedule
   workflow_dispatch:       # Manual trigger
-
+permissions:
+  contents: write   
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -15,19 +16,37 @@ jobs:
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
+      
+      - name: Install system dependencies for R packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjpeg-dev libpng-dev
+
+      - name: Set up Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
 
       - name: Install R dependencies
+        env:
+          GITHUB_PAT: ${{ secrets.gh_pat }}
         run: |
+          Rscript -e 'install.packages("remotes")'
           Rscript -e 'remotes::install_github("e3modelling/gms")'
           Rscript -e 'install.packages("goxygen")'
+          Rscript -e 'install.packages("qgraph")'
 
       - name: Generate docs in temporary folder
         run: |
-          Rscript -e 'goxygen::goxygen(path = "temp_docs", cff = "HOWTOCITE.cff", output = c("html"), includeCore = TRUE)'
+          Rscript -e 'goxygen::goxygen(path = ".", cff = "HOWTOCITE.cff", output = c("html"), includeCore = TRUE, mainfile = "main.gms", startType = "equations")'
+
+      - name: Copy images folder into html folder
+        run: |
+          mkdir -p doc/html/images
+          cp -r doc/images/* doc/html/images/
 
       - name: Deploy to GitHub Pages (root of gh-pages)
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: ./temp_docs/doc/html
+          publish_dir: ./doc/html
+          enable_jekyll: false


### PR DESCRIPTION
Fixes:

1. Install "gms" package from our fork. Even though the gms repo is “public”, e3modelling is private, and GitHub blocks all anonymous API requests to repos inside private orgs and therefore it needs a personal access token (PAT) to the repo. GitHub Actions uses anonymous API access unless you provide a PAT. About PAT safety: The PAT token  is retrieved securely from GitHub’s encrypted secret storage. It is never exposed in logs. It is never printed. It is never shown to other users. Also, the PAT is scoped for read-only access. There is no need write access, delete access, or admin access.
2. install.packages("qgraph") for gms package to plot the interface plots. otherwise it produces no warning on this and it is difficult to find out why it doesn't produce the interface plots.
3. Update the goxygen command with the proper one.
4. Publish only the html folder so github pages can understand the structure but first copy all images from the doc/images inside the html folder.