### PR TITLE
Auto prom magpie

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -143,5 +143,19 @@
             }
         },
 
+        {
+            "label": "OPEN-PROM SOFT-LINK MAgPIE",
+            "type": "shell",
+            "command": "Rscript start.R task=7",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "focus": true
+            }
+        },
+
     ]
 }

--- a/config.template.json
+++ b/config.template.json
@@ -2,6 +2,7 @@
     "model_runs_path": "local\\path\\to\\model\\runs",
     "magpie_path": "path\\to\\magpie\\folder\\including\\trailing\\slash\\",
     "gams_path": "path\\to\\gams\\folder\\including\\trailing\\slash\\",
+    "task7_existingRun": "path\\to\\existing\\model\\run\\for\\task7",
     "scenario_name": "SCEN",
     "description": "Model run description. Replace with your own, based on scenario and model settings."
 }

--- a/config.template.json
+++ b/config.template.json
@@ -1,5 +1,6 @@
 {
     "model_runs_path": "local\\path\\to\\model\\runs",
+    "magpie_path": "path\\to\\magpie\\folder\\including\\trailing\\slash\\",
     "gams_path": "path\\to\\gams\\folder\\including\\trailing\\slash\\",
     "scenario_name": "SCEN",
     "description": "Model run description. Replace with your own, based on scenario and model settings."

--- a/start.R
+++ b/start.R
@@ -431,33 +431,61 @@ if (task == 0) {
   #            -> reportOutput.R (postprom)
   saveMetadata(DevMode = 0)
   sceName <- "SSP2-PkBudg650"
-  if (withRunFolder) createRunFolder(setScenarioName(sceName))
 
-  openPromRun <- getwd()
   magpieRoot  <- NULL
+  existingRun <- NULL
   if (file.exists("config.json")) {
-    config <- fromJSON("config.json")
-    magpieRoot <- config$magpie_path
+    config      <- fromJSON("config.json")
+    magpieRoot  <- config$magpie_path
+    existingRun <- config$task7_existingRun
   }
   if (is.null(magpieRoot) || !nzchar(magpieRoot)) {
     stop("[task 7] config.json must define magpie_path (absolute path to the magpie/ directory).")
   }
+
+  reuseExisting <- !is.null(existingRun) && nzchar(existingRun)
+  if (reuseExisting) {
+    if (!dir.exists(existingRun)) {
+      stop("[task 7] task7_existingRun folder does not exist: ", existingRun)
+    }
+    openPromRun <- normalizePath(existingRun, winslash = "/", mustWork = TRUE)
+    setwd(openPromRun)
+    cat(">>> [task 7] reusing existing run folder:", openPromRun, "\n")
+  } else {
+    if (withRunFolder) createRunFolder(setScenarioName(sceName))
+    openPromRun <- getwd()
+  }
   couplingMif <- file.path(openPromRun, "openprom_coupling.mif")
 
   # ---- Step 1: OPEN-PROM run with link2MAgPIE = off -----------------------
-  cat(">>> [task 7] Step 1/6: OPEN-PROM run (link2MAgPIE=off)\n")
-  cmd1 <- paste0(gams,
-                 " main.gms --DevMode=0 --GenerateInput=off --link2MAgPIE=off",
-                 " -logOption 4 -Idir=./data 2>&1")
-  if (.Platform$OS.type == "unix") {
-    system(paste0("sh -c ", shQuote(cmd1)))
+  if (!reuseExisting) {
+    cat(">>> [task 7] Step 1/6: OPEN-PROM run (link2MAgPIE=off)\n")
+    cmd1 <- paste0(gams,
+                   " main.gms --DevMode=0 --GenerateInput=off --link2MAgPIE=off",
+                   " -logOption 4 -Idir=./data 2>&1")
+    if (.Platform$OS.type == "unix") {
+      system(paste0("sh -c ", shQuote(cmd1)))
+    } else {
+      shell(paste0(cmd1, " | tee full_round1.log"))
+    }
+    if (!isRunSuccessful("modelstat.txt")) {
+      stop("[task 7] First OPEN-PROM run failed. Aborting soft-link.")
+    }
+    file.copy(file.path(openPromRun, "blabla.gdx"),
+              file.path(openPromRun, "blabla_round1.gdx"),
+              overwrite = TRUE)
   } else {
-    shell(paste0(cmd1, " | tee full_round1.log"))
+    cat(">>> [task 7] Step 1/6: SKIPPED (reusing existing round-1)\n")
+    if (!file.exists(file.path(openPromRun, "blabla_round1.gdx"))) {
+      srcGdx <- file.path(openPromRun, "blabla.gdx")
+      if (!file.exists(srcGdx)) {
+        stop("[task 7] Existing run folder has neither blabla_round1.gdx nor blabla.gdx: ",
+             openPromRun)
+      }
+      file.copy(srcGdx, file.path(openPromRun, "blabla_round1.gdx"), overwrite = FALSE)
+    }
   }
-  if (!isRunSuccessful("modelstat.txt")) {
-    stop("[task 7] First OPEN-PROM run failed. Aborting soft-link.")
-  }
-  openPromGdx <- file.path(openPromRun, "blabla.gdx")
+  openPromGdx <- file.path(openPromRun, "blabla_round1.gdx")
 
   # ---- Step 2: OPEN-PROM -> MAgPIE via couplePromToMagpie() --------------
   cat(">>> [task 7] Step 2/6: couplePromToMagpie() -> ", couplingMif, "\n")

--- a/start.R
+++ b/start.R
@@ -3,7 +3,7 @@ library(jsonlite)
 
 # Various flags used to modify script behavior
 withRunFolder <- TRUE # Set to FALSE to disable model run folder creation and file copying
-withSync <- TRUE # Set to FALSE to disable model run sync to SharePoint
+withSync <- FALSE # Set to FALSE to disable model run sync to SharePoint
 withReport <- TRUE # Set to FALSE to disable the report output script execution (applicable to research mode only)
 uploadGDX <- TRUE # Set to TRUE to include GDX files in the uploaded archive
 
@@ -175,6 +175,7 @@ setScenarioName <- function(scen_default) {
 
   return(scen)
 }
+
 ### Function that check if all country and year runs are successfull
 isRunSuccessful <- function(statusFilePath) {
   if (!file.exists(statusFilePath)) return(FALSE)
@@ -416,6 +417,107 @@ if (task == 0) {
     setwd("../../") # Going back to root folder
     cat("Executing the report output script\n")
     report_cmd <- paste0("Rscript ./reportOutput.R ", run_path) # Executing the report output script on the current run path
+    system(report_cmd)
+    setwd(run_path)
+  }
+  if (withRunFolder && withSync) syncRun()
+} else if (task == 7) {
+  # Running task OPEN-PROM <-> MAgPIE SOFT-LINK
+  # Pipeline: open-prom (link2MAgPIE=off)
+  #            -> linkPromToMagpie(forward = TRUE)    # OPEN-PROM -> MAgPIE
+  #            -> magpie (Rscript start.R)
+  #            -> linkPromToMagpie(forward = FALSE)   # MAgPIE2OPEN()
+  #            -> open-prom (link2MAgPIE=on)
+  #            -> reportOutput.R (postprom)
+  saveMetadata(DevMode = 0)
+  sceName <- "SOFTLINKMAGPIE"
+  if (withRunFolder) createRunFolder(setScenarioName(sceName))
+
+  # After createRunFolder() we are in OPEN-PROM/runs/<scen>_<ts>/.
+  # Go up THREE levels to reach the repo root where magpie/ lives.
+  openPromRun <- getwd()
+  magpieRoot  <- NULL
+  if (file.exists("config.json")) {
+    config <- fromJSON("config.json")
+    magpieRoot <- config$magpie_path
+  }
+  f56 <- file.path(magpieRoot, "modules", "56_ghg_policy", "input", "f56_pollutant_prices.cs3")
+  f60 <- file.path(magpieRoot, "modules", "60_bioenergy", "input", "f60_1stgen_bioenergy_dem.cs3")
+  linkOutDir  <- paste0(openPromRun, "/") # linkPromToMagpie uses paste0(pathsave, ...), trailing slash required
+
+  # ---- Step 1: OPEN-PROM run with link2MAgPIE = off -----------------------
+  cat(">>> [task 7] Step 1/6: OPEN-PROM run (link2MAgPIE=off)\n")
+  cmd1 <- paste0(gams,
+                 " main.gms --DevMode=0 --GenerateInput=off --link2MAgPIE=off",
+                 " -logOption 4 -Idir=./data 2>&1")
+  if (.Platform$OS.type == "unix") {
+    system(paste0("sh -c ", shQuote(cmd1)))
+  } else {
+    shell(paste0(cmd1, " | tee full_round1.log"))
+  }
+  if (!isRunSuccessful("modelstat.txt")) {
+    stop("[task 7] First OPEN-PROM run failed. Aborting soft-link.")
+  }
+  openPromGdx <- file.path(openPromRun, "blabla.gdx")
+
+  # ---- Step 2: OPEN-PROM -> MAgPIE via linkPromToMagpie(forward = TRUE) ---
+  cat(">>> [task 7] Step 2/6: linkPromToMagpie(forward = TRUE)\n")
+  library(postprom)
+  linkPromToMagpie(
+    path                = openPromGdx,
+    pathPollutantPrices = f56,
+    pathsave            = linkOutDir,
+    pathBioenergyDemand = f60,
+    forward             = TRUE,
+    scenario            = sceName
+  )
+  # Overwrite MAgPIE inputs with the freshly generated cs3 files
+  file.copy(file.path(linkOutDir, "result_f56_pollutant_prices.cs3"),     f56, overwrite = TRUE)
+  file.copy(file.path(linkOutDir, "result_f60_1stgen_bioenergy_dem.cs3"), f60, overwrite = TRUE)
+
+  # ---- Step 3: MAgPIE run -------------------------------------------------
+  cat(">>> [task 7] Step 3/6: MAgPIE run\n")
+  setwd(magpieRoot)
+  magpie_exit <- system("Rscript start.R")
+  if (magpie_exit != 0) {
+    setwd(openPromRun)
+    stop("[task 7] MAgPIE run failed with exit code ", magpie_exit, ".")
+  }
+  magpieOutDirs <- list.dirs("output", recursive = FALSE)
+  latestMagpieRun <- magpieOutDirs[which.max(file.info(magpieOutDirs)$mtime)]
+  magpieGdx       <- file.path(normalizePath(latestMagpieRun, winslash = "/"), "fulldata.gdx")
+  magpieReport    <- file.path(normalizePath(latestMagpieRun, winslash = "/"), "report.mif")
+
+  # ---- Step 4: MAgPIE -> OPEN-PROM via linkPromToMagpie(forward = FALSE) --
+  cat(">>> [task 7] Step 4/6: linkPromToMagpie(forward = FALSE) == MAgPIE2OPEN\n")
+  setwd(openPromRun)
+  linkPromToMagpie(
+    path                = magpieGdx,
+    pathPollutantPrices = NULL,
+    pathsave            = NULL,
+    pathBioenergyDemand = NULL,
+    pathReport          = magpieReport,
+    pathSave            = openPromRun,
+    forward             = FALSE
+  )
+
+  # ---- Step 5: OPEN-PROM run with link2MAgPIE = on ------------------------
+  cat(">>> [task 7] Step 5/6: OPEN-PROM run (link2MAgPIE=on)\n")
+  cmd2 <- paste0(gams,
+                 " main.gms --DevMode=0 --GenerateInput=off --link2MAgPIE=on",
+                 " -logOption 4 -Idir=./data 2>&1")
+  if (.Platform$OS.type == "unix") {
+    system(paste0("sh -c ", shQuote(cmd2)))
+  } else {
+    shell(paste0(cmd2, " | tee full_round2.log"))
+  }
+
+  # ---- Step 6: postprom / reportOutput.R + sync ---------------------------
+  if (withRunFolder && withReport) {
+    cat(">>> [task 7] Step 6/6: reportOutput.R\n")
+    run_path <- getwd()
+    setwd("../../") # Going back to OPEN-PROM root
+    report_cmd <- paste0("Rscript ./reportOutput.R ", run_path)
     system(report_cmd)
     setwd(run_path)
   }

--- a/start.R
+++ b/start.R
@@ -4,7 +4,7 @@ library(jsonlite)
 # Various flags used to modify script behavior
 withRunFolder <- TRUE # Set to FALSE to disable model run folder creation and file copying
 withSync <- FALSE # Set to FALSE to disable model run sync to SharePoint
-withReport <- TRUE # Set to FALSE to disable the report output script execution (applicable to research mode only)
+withReport <- FALSE # Set to FALSE to disable the report output script execution (applicable to research mode only)
 uploadGDX <- TRUE # Set to TRUE to include GDX files in the uploaded archive
 
 ### Define function that saves model metadata into a JSON file.
@@ -422,28 +422,27 @@ if (task == 0) {
   }
   if (withRunFolder && withSync) syncRun()
 } else if (task == 7) {
-  # Running task OPEN-PROM <-> MAgPIE SOFT-LINK
+  # Running task OPEN-PROM <-> MAgPIE SOFT-LINK (coupling-channel, mif-based)
   # Pipeline: open-prom (link2MAgPIE=off)
-  #            -> linkPromToMagpie(forward = TRUE)    # OPEN-PROM -> MAgPIE
-  #            -> magpie (Rscript start.R)
-  #            -> linkPromToMagpie(forward = FALSE)   # MAgPIE2OPEN()
+  #            -> couplePromToMagpie()   # OPEN-PROM gdx  -> coupling.mif
+  #            -> magpie (Rscript start.R, reads env-vars OPENPROM_COUPLING_*)
+  #            -> coupleMagpieToProm()   # MAgPIE report.mif -> iPrices/iEmissions
   #            -> open-prom (link2MAgPIE=on)
   #            -> reportOutput.R (postprom)
   saveMetadata(DevMode = 0)
-  sceName <- "SOFTLINKMAGPIE"
+  sceName <- "SSP2-PkBudg650"
   if (withRunFolder) createRunFolder(setScenarioName(sceName))
 
-  # After createRunFolder() we are in OPEN-PROM/runs/<scen>_<ts>/.
-  # Go up THREE levels to reach the repo root where magpie/ lives.
   openPromRun <- getwd()
   magpieRoot  <- NULL
   if (file.exists("config.json")) {
     config <- fromJSON("config.json")
     magpieRoot <- config$magpie_path
   }
-  f56 <- file.path(magpieRoot, "modules", "56_ghg_policy", "input", "f56_pollutant_prices.cs3")
-  f60 <- file.path(magpieRoot, "modules", "60_bioenergy", "input", "f60_1stgen_bioenergy_dem.cs3")
-  linkOutDir  <- paste0(openPromRun, "/") # linkPromToMagpie uses paste0(pathsave, ...), trailing slash required
+  if (is.null(magpieRoot) || !nzchar(magpieRoot)) {
+    stop("[task 7] config.json must define magpie_path (absolute path to the magpie/ directory).")
+  }
+  couplingMif <- file.path(openPromRun, "openprom_coupling.mif")
 
   # ---- Step 1: OPEN-PROM run with link2MAgPIE = off -----------------------
   cat(">>> [task 7] Step 1/6: OPEN-PROM run (link2MAgPIE=off)\n")
@@ -460,45 +459,46 @@ if (task == 0) {
   }
   openPromGdx <- file.path(openPromRun, "blabla.gdx")
 
-  # ---- Step 2: OPEN-PROM -> MAgPIE via linkPromToMagpie(forward = TRUE) ---
-  cat(">>> [task 7] Step 2/6: linkPromToMagpie(forward = TRUE)\n")
+  # ---- Step 2: OPEN-PROM -> MAgPIE via couplePromToMagpie() --------------
+  cat(">>> [task 7] Step 2/6: couplePromToMagpie() -> ", couplingMif, "\n")
   library(postprom)
-  linkPromToMagpie(
-    path                = openPromGdx,
-    pathPollutantPrices = f56,
-    pathsave            = linkOutDir,
-    pathBioenergyDemand = f60,
-    forward             = TRUE,
-    scenario            = sceName
+  # Source the coupling helpers directly so edits in postprom/R/ take effect
+  # without requiring a package reinstall.
+  source(file.path(openPromRun, "..", "..", "postprom", "R", "couplePromWithMagpie.R"))
+  couplePromToMagpie(
+    gdxPath    = openPromGdx,
+    outMifPath = couplingMif,
+    scenario   = sceName
   )
-  # Overwrite MAgPIE inputs with the freshly generated cs3 files
-  file.copy(file.path(linkOutDir, "result_f56_pollutant_prices.cs3"),     f56, overwrite = TRUE)
-  file.copy(file.path(linkOutDir, "result_f60_1stgen_bioenergy_dem.cs3"), f60, overwrite = TRUE)
 
-  # ---- Step 3: MAgPIE run -------------------------------------------------
+  # ---- Step 3: MAgPIE run (reads coupling mif via env-vars) --------------
   cat(">>> [task 7] Step 3/6: MAgPIE run\n")
   setwd(magpieRoot)
+  Sys.setenv(
+    OPENPROM_COUPLING_MIF       = couplingMif,
+    OPENPROM_COUPLING_SCENARIO  = sceName,
+    OPENPROM_COUPLING_GHG       = "on",
+    OPENPROM_COUPLING_BIOENERGY = "on"
+  )
   magpie_exit <- system("Rscript start.R")
+  Sys.unsetenv(c("OPENPROM_COUPLING_MIF", "OPENPROM_COUPLING_SCENARIO",
+                 "OPENPROM_COUPLING_GHG", "OPENPROM_COUPLING_BIOENERGY"))
   if (magpie_exit != 0) {
     setwd(openPromRun)
     stop("[task 7] MAgPIE run failed with exit code ", magpie_exit, ".")
   }
-  magpieOutDirs <- list.dirs("output", recursive = FALSE)
+  magpieOutDirs   <- list.dirs("output", recursive = FALSE)
   latestMagpieRun <- magpieOutDirs[which.max(file.info(magpieOutDirs)$mtime)]
-  magpieGdx       <- file.path(normalizePath(latestMagpieRun, winslash = "/"), "fulldata.gdx")
   magpieReport    <- file.path(normalizePath(latestMagpieRun, winslash = "/"), "report.mif")
 
-  # ---- Step 4: MAgPIE -> OPEN-PROM via linkPromToMagpie(forward = FALSE) --
-  cat(">>> [task 7] Step 4/6: linkPromToMagpie(forward = FALSE) == MAgPIE2OPEN\n")
+  # ---- Step 4: MAgPIE -> OPEN-PROM via coupleMagpieToProm() --------------
+  cat(">>> [task 7] Step 4/6: coupleMagpieToProm()\n")
   setwd(openPromRun)
-  linkPromToMagpie(
-    path                = magpieGdx,
-    pathPollutantPrices = NULL,
-    pathsave            = NULL,
-    pathBioenergyDemand = NULL,
-    pathReport          = magpieReport,
-    pathSave            = openPromRun,
-    forward             = FALSE
+  coupleMagpieToProm(
+    reportMifPath       = magpieReport,
+    outCsvPath          = file.path(openPromRun, "iPrices_magpie.csv"),
+    outEmissionsCsvPath = file.path(openPromRun, "iEmissions_magpie.csv"),
+    gdxPath             = openPromGdx
   )
 
   # ---- Step 5: OPEN-PROM run with link2MAgPIE = on ------------------------

--- a/start.R
+++ b/start.R
@@ -462,9 +462,6 @@ if (task == 0) {
   # ---- Step 2: OPEN-PROM -> MAgPIE via couplePromToMagpie() --------------
   cat(">>> [task 7] Step 2/6: couplePromToMagpie() -> ", couplingMif, "\n")
   library(postprom)
-  # Source the coupling helpers directly so edits in postprom/R/ take effect
-  # without requiring a package reinstall.
-  source(file.path(openPromRun, "..", "..", "postprom", "R", "couplePromWithMagpie.R"))
   couplePromToMagpie(
     gdxPath    = openPromGdx,
     outMifPath = couplingMif,

--- a/tutorials/12_Soft-Linking Tutorial OPEN-PROM-MAgPIE.md
+++ b/tutorials/12_Soft-Linking Tutorial OPEN-PROM-MAgPIE.md
@@ -1,24 +1,26 @@
 
-# 🌍 Soft-Linking Tutorial: OPEN-PROM ↔ MAgPIE
+# Soft-Linking Tutorial: OPEN-PROM ↔ MAgPIE (coupling-channel)
 
-This guide explains how to use the soft-linking functionality between the **OPEN-PROM** energy system model and the **MAgPIE** land-use model using two R functions:
+This guide explains how to run the soft-coupling between the **OPEN-PROM** energy-system model and the **MAgPIE** land-use model via the **coupling-channel** approach — the mif-based interface that MAgPIE already exposes for REMIND (`c56_pollutant_prices = "coupling"`, `c60_2ndgen_biodem = "coupling"`).
 
-- `linkPromToMagpie()` → For exporting data from **OPEN-PROM to MAgPIE**.
-- `MAgPIE2OPEN()` → For importing data from **MAgPIE to OPEN-PROM**.
+Two R functions (in `postprom/R/couplePromWithMagpie.R`) do the data exchange:
 
-It also describes the internal **model switch logic** implemented in `OPEN-PROM` to conditionally enable or disable this integration.
+* `couplePromToMagpie()` — exports OPEN-PROM carbon price + bioenergy demand to a REMIND-style `.mif` that MAgPIE consumes
+* `coupleMagpieToProm()` — reads MAgPIE's `report.mif` and writes `iPrices_magpie.csv` (biomass price) and `iEmissions_magpie.csv` (AFOLU emissions) for OPEN-PROM
+
+All of this is orchestrated by `task == 7` in `start.R`.
 
 ---
 
-## ⚙️ Model Integration Switch (in OPEN-PROM)
+## Model Integration Switch (OPEN-PROM side)
 
-OPEN-PROM includes a conditional switch that enables or disables the use of MAgPIE-derived inputs. This is done using the global flag:
+A global GAMS flag toggles whether OPEN-PROM reads MAgPIE-derived biomass prices:
 
 ```gams
 $setGlobal link2MAgPIE on
 ```
 
-In `input.gms`, a conditional block reads MAgPIE-based biomass prices **only if the switch is activated**:
+`modules/08_Prices/legacy/input.gms` conditionally reads the price table only when the switch is on:
 
 ```gams
 $ifthen %link2MAgPIE% == on
@@ -30,84 +32,81 @@ $offdelim
 $endif
 ```
 
-In the **preloop** phase, the fuel price values are set via:
+In the **preloop** phase, the biomass fuel price is fixed to the MAgPIE-supplied value:
 
 ```gams
-$IF %link2MAgPIE% == on 
+$IF %link2MAgPIE% == on
 VmPriceFuelSubsecCarVal.FX(runCy,SBS,"BMSWAS",YTIME)$(An(YTIME)) = iPricesMagpie(runCy,SBS,YTIME);
 ```
 
-In the **equation definitions**, the switch logic is embedded using a combination of `$IFTHEN` and `$(...)`:
+And the price-formation equation in `modules/08_Prices/legacy/equations.gms:21` excludes `BMSWAS` from the regular price-recursion when the switch is on (`$(not sameas("BMSWAS",EF))`).
 
-```gams
-Q08PriceFuelSubsecCarVal(allCy,SBS,EF,YTIME)$(SECTTECH(SBS,EF) $TIME(YTIME)
-$IFTHEN %link2MAgPIE% == on 
-   $(not sameas("BMSWAS",EF))
-$ENDIF
-   $(not sameas("NUC",EF)) $runCy(allCy))..
-   VmPriceFuelSubsecCarVal(allCy,SBS,EF,YTIME) =E= ...
-```
-
-This ensures that if the user sets `link2MAgPIE = on`, MAgPIE-derived values will override default ones for bioenergy prices and emissions.
+The reverse-direction switch on the MAgPIE side is triggered by environment variables — `magpie/start.R` sets `cfg$gms$c56_pollutant_prices = "coupling"` and `cfg$gms$c60_2ndgen_biodem = "coupling"` when `OPENPROM_COUPLING_MIF` is defined. With the env-vars unset, MAgPIE's default behaviour is unchanged.
 
 ---
 
-## 🔄 R Code for Data Exchange
+## R functions
 
-### 1️⃣ From OPEN-PROM → MAgPIE
-
-This direction is triggered using the following R command:
+### 1. OPEN-PROM → MAgPIE
 
 ```r
-linkPromToMagpie("path/to/output.gdx", 
-                 "path/to/f56_pollutant_prices.cs3", 
-                 "path/to/f60_1stgen_bioenergy_dem.cs3")
+library(postprom)
+couplePromToMagpie(
+  gdxPath    = "path/to/blabla.gdx",          # OPEN-PROM round-1 gdx
+  outMifPath = "path/to/openprom_coupling.mif",
+  scenario   = "SSP2-PkBudg650"               # must match MAgPIE side
+)
 ```
 
-This function:
-- Extracts **carbon prices** and **bioenergy demand** from an OPEN-PROM `.gdx` file.
-- Converts carbon prices to MAgPIE's expected format (in CO2 pollutant units).
-- Converts bioenergy demand from **Mtoe → PJ**, aggregated to MAgPIE's regions.
-- Writes two `.cs3` files that MAgPIE uses as scenario-specific inputs:
-  - `f56_pollutant_prices.cs3` (carbon price trajectories)
-  - `f60_1stgen_bioenergy_dem.cs3` (bioenergy demand)
+What it does:
 
-These outputs are then copied into MAgPIE’s input folders before its execution.
+* Extracts `VmCarVal[,"TRADE",]` (CO2 price, US$2015/t CO2) and converts to US$2017 via a 1.04 deflator
+* Extracts `V03InpTotTransf[,"LQD","BMSWAS",]` (2G lignocellulosic feedstock, Mtoe/yr) and converts to EJ/yr (× 0.041868)
+* Derives `Price|N2O` (× AR6 GWP100 = 273) and `Price|CH4` (× 27) from the CO2 price — MAgPIE requires all three GHG prices present
+* Aggregates OPEN-PROM's 39 countries to MAgPIE's 12 h12 regions (EU-28 → `EUR`, the other 11 countries map 1:1)
+* Writes a REMIND-style `.mif` with 4 variables × 12 regions × 91 years that MAgPIE can consume via `cfg$path_to_report_ghgprices` / `cfg$path_to_report_bioenergy`
 
----
-
-### 2️⃣ From MAgPIE → OPEN-PROM
-
-After running MAgPIE, the reverse link is executed using:
+### 2. MAgPIE → OPEN-PROM
 
 ```r
-MAgPIE2OPEN("path/to/input.gdx", 
-            "path/to/output/report.mif", 
-            "path/to/OPEN-PROM/input/folder/")
+coupleMagpieToProm(
+  reportMifPath       = "path/to/magpie/output/noAR_.../report.mif",
+  outCsvPath          = "path/to/openprom/run/iPrices_magpie.csv",
+  outEmissionsCsvPath = "path/to/openprom/run/iEmissions_magpie.csv",
+  gdxPath             = "path/to/blabla.gdx"  # used to read the SBS set
+)
 ```
 
-This function:
-- Reads the `.mif` report from MAgPIE and extracts:
-  - **Biomass prices** (converted to USD2015/toe).
-  - **Land-use emissions** (CO2 and other gases).
-- Processes and interpolates the results.
-- Converts MAgPIE region format to match OPEN-PROM.
-- Saves two CSV files in OPEN-PROM format:
-  - `iPrices_magpie.csv` – bioenergy fuel prices by sector and region
-  - `iEmissions_magpie.csv` – emissions data from the AFOLU sector
+What it does:
 
-These files are then picked up by OPEN-PROM during its second model run, completing the loop.
+* Reads `Prices|Bioenergy (US$2017/GJ)` and converts to OPEN-PROM's k$2015/toe (× 0.96 × 41.868 / 1000)
+* Interpolates MAgPIE's 5-year steps onto OPEN-PROM's `YTIME = 2010..2100` annual grid
+* Disaggregates MAgPIE's 12 h12 regions back to OPEN-PROM's 39 countries (EU-28 members inherit the `EUR` value; other 11 regions 1:1) and broadcasts across the 34 `SBS` subsectors — writes `iPrices_magpie.csv` (the file that the GAMS switch above reads)
+* Also reads 11 AFOLU emission variables (`Emissions|CO2|Land`, `CH4|Land`, `N2O|Land`, fire-related BC/CO/OC/SO2/VOC, NH3, NO2, NO3-) and writes `iEmissions_magpie.csv`. **The GAMS side does not currently `$include` this file** — it is produced and saved for future extension
 
 ---
 
-## 🔁 Full Workflow
+## Full Workflow (automated by `start.R task 7`)
 
-The full sequence for executing the soft-link is:
+```r
+source("start.R")  # with task <- 7
+```
 
-1. Run OPEN-PROM with `link2MAgPIE = off` to generate carbon prices and bioenergy demand.
-2. Execute `linkPromToMagpie()` to generate MAgPIE input files.
-3. Run MAgPIE using the updated `.cs3` input files.
-4. Execute `MAgPIE2OPEN()` to extract and reformat the outputs.
-5. Run OPEN-PROM again with `link2MAgPIE = on` to finalize results using land-informed biomass prices and emissions.
+Pipeline:
 
-This setup ensures a flexible and traceable workflow for coupling energy system and land-use models using a modular and scenario-driven approach. The conditional GAMS switches allow seamless toggling, while the R script handles all the data transformations.
+1. **OPEN-PROM round-1** (`link2MAgPIE=off`) → `blabla.gdx`
+2. `couplePromToMagpie()` → `openprom_coupling.mif`
+3. **MAgPIE run** — launched via `Rscript start.R` inside `magpie/`, with env-vars `OPENPROM_COUPLING_MIF`, `OPENPROM_COUPLING_SCENARIO`, `OPENPROM_COUPLING_GHG=on`, `OPENPROM_COUPLING_BIOENERGY=on` set; MAgPIE writes `report.mif`
+4. `coupleMagpieToProm()` → `iPrices_magpie.csv` + `iEmissions_magpie.csv`
+5. **OPEN-PROM round-2** (`link2MAgPIE=on`) — reads `iPrices_magpie.csv`, fixes BMSWAS price, re-solves
+6. `reportOutput.R` + sync
+
+`config.json` must define `magpie_path` (absolute path to the MAgPIE root) so task 7 knows where to launch the land-use run.
+
+---
+
+## Notes
+
+* CSV format requirement: year column headers in `iPrices_magpie.csv` must be **bare integers** (`2010,2011,…,2100`) — no `y` prefix. OPEN-PROM's `YTIME` set is declared as `/%fStartHorizon%*%fEndHorizon%/` which expands to plain-integer labels, and any mismatch triggers GAMS error 170 (domain violation)
+* When launching GAMS from `start.R`, always pass `-Idir=./data` because `core/input.gms` includes CSVs with root-relative paths (`./iActv.csvr` etc.) that live in the `./data/` subdirectory
+* The forward bio channel sends `V03InpTotTransf[,"LQD","BMSWAS",]` — the narrow 2G lignocellulosic feedstock flow. Under scenarios where OPEN-PROM does not activate the liquid biofuel pathway, this signal can legitimately be near-zero; the CO2 price channel still transmits independently

--- a/tutorials/12_Soft-Linking Tutorial OPEN-PROM-MAgPIE.md
+++ b/tutorials/12_Soft-Linking Tutorial OPEN-PROM-MAgPIE.md
@@ -94,14 +94,78 @@ source("start.R")  # with task <- 7
 
 Pipeline:
 
-1. **OPEN-PROM round-1** (`link2MAgPIE=off`) → `blabla.gdx`
-2. `couplePromToMagpie()` → `openprom_coupling.mif`
+1. **OPEN-PROM round-1** (`link2MAgPIE=off`) → `blabla.gdx` + `blabla_round1.gdx` snapshot
+2. `couplePromToMagpie()` → `openprom_coupling.mif` (reads `blabla_round1.gdx`)
 3. **MAgPIE run** — launched via `Rscript start.R` inside `magpie/`, with env-vars `OPENPROM_COUPLING_MIF`, `OPENPROM_COUPLING_SCENARIO`, `OPENPROM_COUPLING_GHG=on`, `OPENPROM_COUPLING_BIOENERGY=on` set; MAgPIE writes `report.mif`
 4. `coupleMagpieToProm()` → `iPrices_magpie.csv` + `iEmissions_magpie.csv`
-5. **OPEN-PROM round-2** (`link2MAgPIE=on`) — reads `iPrices_magpie.csv`, fixes BMSWAS price, re-solves
+5. **OPEN-PROM round-2** (`link2MAgPIE=on`) — reads `iPrices_magpie.csv`, fixes BMSWAS price, re-solves; overwrites `blabla.gdx` with the round-2 result (the round-1 snapshot is preserved)
 6. `reportOutput.R` + sync
 
 `config.json` must define `magpie_path` (absolute path to the MAgPIE root) so task 7 knows where to launch the land-use run.
+
+### Run-folder layout (what each step produces)
+
+A successful task 7 run touches **two folders**: the OPEN-PROM run folder created by Step 1 (`createRunFolder`) and a fresh MAgPIE output folder created by Step 3.
+
+```
+runs/SSP2-PkBudg650_<timestamp>/                  ← OPEN-PROM run folder
+├── blabla.gdx                                    Step 1 output → Step 5 overwrites with round-2
+├── blabla_round1.gdx                             Step 1 snapshot; Step 2 reads only this; preserved across resumes
+├── outputData.gdx                                round-2 OPEN-PROM main GDX (used by Step 6)
+├── modelstat.txt                                 GAMS model status of the latest solve (Step 5 overwrites Step 1's)
+├── main.lst / main.log                           GAMS listing & log of the latest solve
+├── full_round1.log                               Windows only: tee'd Step 1 console log
+├── full_round2.log                               Windows only: tee'd Step 5 console log
+├── openprom_coupling.mif                         Step 2 output → MAgPIE Step 3 input
+├── iPrices_magpie.csv                            Step 4 output → Step 5 input (BMSWAS price table)
+├── iEmissions_magpie.csv                         Step 4 output (AFOLU; produced for completeness, GAMS does not yet read it)
+├── reporting.mif                                 Step 6 (`convertGDXtoMIF`) — converted MIF report
+├── plot.tex / plot.pdf                           Step 6 (`batchPlotReport`) — auto-generated plots
+└── metadata.json                                 written by `saveMetadata()` at task entry
+
+magpie/output/noAR_<timestamp>/                   ← created by Step 3, one new folder per MAgPIE run
+├── report.mif                                    Step 3 output → Step 4 input
+├── fulldata.gdx                                  MAgPIE main GDX
+├── full.log / full.lst                           GAMS log/listing
+├── runstatistics.rda                             runtime stats
+└── _renv.lock / renv.lock                        per-run renv snapshot
+
+<config$model_runs_path>/                         ← SharePoint / shared drive (Step 6 sync target)
+└── SSP2-PkBudg650_<timestamp>.tgz                tar-gzipped copy of the OPEN-PROM run folder
+```
+
+Notes on file lifetimes:
+
+* `blabla.gdx` is produced twice (Step 1, then overwritten in Step 5). `blabla_round1.gdx` is the immutable round-1 snapshot — every resume reads from it, never from `blabla.gdx`.
+* `modelstat.txt`, `main.lst`, `main.log` likewise reflect only the *latest* solve. If Step 5 finishes, you cannot tell from these whether Step 1 also succeeded — but `blabla_round1.gdx` proves it did.
+* The MAgPIE step always creates a *new* timestamped subfolder under `magpie/output/`, so resuming task 7 leaves the previous MAgPIE folder untouched and Step 4 picks the most recent one (`which.max(mtime)`).
+* `syncRun()` writes the `.tgz` archive locally first, copies it to `config$model_runs_path`, then deletes the local copy. Excludes `main.lst` / `mainCalib.lst` on success; the `uploadGDX` flag in `start.R` controls whether `.gdx` files are included.
+
+---
+
+## Resuming from an Existing Run
+
+If a task 7 run fails mid-pipeline (e.g. MAgPIE crashes in Step 3) and you want to retry without paying the cost of OPEN-PROM round-1 again, point the optional `task7_existingRun` field in `config.json` at the existing run folder:
+
+```json
+{
+  "model_runs_path": "...",
+  "magpie_path":     "...",
+  "task7_existingRun": "/abs/path/to/runs/SSP2-PkBudg650_2026-04-25_xxx"
+}
+```
+
+When this field is non-empty, `start.R`:
+
+* skips Step 1 (the round-1 GAMS solve),
+* `cd`s into the named folder instead of creating a new one, and
+* resumes from Step 2.
+
+Outputs from Step 2–6 overwrite previous artefacts in place, so a re-run after a Step 3 failure simply rewrites `openprom_coupling.mif`, picks up the next MAgPIE output folder, and re-solves round-2.
+
+**Why the `blabla_round1.gdx` snapshot matters.** Step 5 overwrites `blabla.gdx` with the round-2 result. Without a snapshot, a resume started after Step 5 would feed the round-2 gdx back into `couplePromToMagpie()` — wrong coupling input. Step 1 success therefore always copies `blabla.gdx → blabla_round1.gdx`, and Step 2 reads only from the `_round1` snapshot. If you point `task7_existingRun` at a folder produced before this feature landed (only `blabla.gdx`, no snapshot), the script makes the snapshot once on first reuse.
+
+**Disabling resumption.** `"task7_existingRun": ""`, `"task7_existingRun": null`, or simply omitting the field — all three are treated as "run from scratch".
 
 ---
 


### PR DESCRIPTION
# Task 7: OPEN-PROM ↔ MAgPIE Soft-coupling (coupling-channel approach)

This change switches the OPEN-PROM ↔ MAgPIE soft-link from the old "cs3 file overwrite" path to the **coupling-channel approach** — i.e. the mif-based interface that MAgPIE already exposes for REMIND (`c56_pollutant_prices = "coupling"`, `c60_2ndgen_biodem = "coupling"`). A REMIND-style `.mif` serves as the forward channel, and MAgPIE's `report.mif` serves as the backward channel.

## 1. Change list

* **New file `postprom/R/couplePromWithMagpie.R`** (367 lines) — two entry functions:
  * `couplePromToMagpie(gdxPath, outMifPath, scenario, ...)`: extracts the carbon price and narrow-definition bioenergy from OPEN-PROM's `blabla.gdx` and writes a REMIND-style mif for MAgPIE to consume
  * `coupleMagpieToProm(reportMifPath, outCsvPath, outEmissionsCsvPath, gdxPath)`: reads MAgPIE's `report.mif`, disaggregates `Prices|Bioenergy` back to OPEN-PROM's 39 resCy × 34 SBS, writes `iPrices_magpie.csv`; also writes `iEmissions_magpie.csv` (AFOLU emissions, reserved for future extension)
* **Removed legacy file `postprom/R/linkPromToMagpie.R`** — the old cs3-overwrite interface is fully superseded by the coupling-channel (mif) approach and is no longer maintained. The corresponding `export(linkPromToMagpie)` line in `postprom/NAMESPACE` is also removed
* **Rewrote `tutorials/12_Soft-Linking Tutorial OPEN-PROM-MAgPIE.md`** — the old doc described the `linkPromToMagpie()` + `.cs3` flow; it has been rewritten to describe the new `couplePromToMagpie()` / `coupleMagpieToProm()` + `.mif` flow
* **`postprom/NAMESPACE`** — added `export(couplePromToMagpie)` and `export(coupleMagpieToProm)`
* **`start.R` new `task == 7` branch** (lines 424-525) — end-to-end pipeline: OPEN-PROM round-1 (link2MAgPIE=off) → `couplePromToMagpie()` → MAgPIE run → `coupleMagpieToProm()` → OPEN-PROM round-2 (link2MAgPIE=on) → postprom report. The `magpie_path` field in `config.json` is used to locate the MAgPIE root directory
* **`magpie/start.R`** — added an env-var-triggered coupling config block (lines 42-60). If `OPENPROM_COUPLING_MIF` is set, `cfg$path_to_report_ghgprices`, `cfg$path_to_report_bioenergy` and the corresponding `cfg$gms$c56_pollutant_prices`, `cfg$gms$c60_2ndgen_biodem` are switched to `"coupling"`. When the env-vars are unset, MAgPIE's default behavior is entirely unchanged. **Note:** the file also contains a commented-out line `# cfg <- setScenario(cfg,"noAR",scenario_config="./scenario_config_mUPTAKE.csv")` — the current code **does not** use this csv because its format does not match what MAgPIE's `setScenario` expects (it errors out in testing). The comment is kept as a placeholder only; if a reviewer wants to enable noAR or a custom scenario, they should rewrite the csv to MAgPIE's standard format first, then uncomment the line

## 2. Forward channel: OPEN-PROM → MAgPIE

### 2.1 The coupling mif is a separate channel from the existing mif

OPEN-PROM's existing mif output is produced by `reportOutput.R` → `postprom::convertGDXtoMIF()` — a wide-variable report mif used for piamValidation / plotting. **Task 7's coupling mif is entirely separate:**

* Fixed filename `openprom_coupling.mif`, written at the run folder root
* Contains only 4 variables (Price|Carbon, Price|N2O, Price|CH4, Primary Energy Production|Biomass|Energy Crops), 12 h12 regions, sparse years
* Written by `couplePromToMagpie()` via a dedicated `magclass::write.report()` call — does not go through `convertGDXtoMIF` and does not touch postprom's reportXxx functions
* MAgPIE reads it back via `cfg$path_to_report_ghgprices = openprom_coupling.mif`, using the same mechanism as the existing REMIND coupling interface

### 2.2 The biomass passed to MAgPIE is "energy-transformation input" (narrow definition)

Inside OPEN-PROM biomass (`BMSWAS`) flows into several destinations:

* `V03ConsGrssInl[,"BMSWAS",]` — gross inland consumption, including household firewood, industrial direct burning, etc. (**not used**)
* `V03InpTotTransf[,SSBS,"BMSWAS",]` — biomass input to the energy-transformation stage (**use this**)

We take only **`V03InpTotTransf[,"LQD","BMSWAS",]`** — the biomass feedstock entering the LQD (liquid fuel) transformation pathway. The reason is **source matching**, not "end use vs transformation":

* The MAgPIE `c60_2ndgen_biodem` interface specifically receives **2nd-generation lignocellulosic bioenergy demand** — the portion MAgPIE needs to plan dedicated energy crops (short-rotation coppice, perennial grasses) or organize agricultural/forestry residue supply chains for
* OPEN-PROM's `V03InpTotTransf[,"LQD","BMSWAS",]` (feedstock input into 2G liquid biofuel) is **the closest match in source structure to 2G** — the mainstream feedstock for liquid-biofuel transformation is lignocellulosic, which aligns with MAgPIE's `c60_2ndgen_biodem`
* Other BMSWAS destinations have **different sources** and should not be passed to MAgPIE as 2G energy-crop demand:
  * **Household firewood** — mostly locally foraged forest wood / waste wood, not part of MAgPIE's cropland / plantation planning account
  * **Industrial direct burning** (paper black liquor, sugar-mill bagasse, sawdust) — process residues, MAgPIE tracks residue supply separately
  * **`V03InpTotTransf[,"PG"/"CHP"/"SLD","BMSWAS",]`** — mixed sources (wood pellets + bio-waste + some energy crops); passing the whole lump as 2G energy-crop demand would cause MAgPIE to **over-allocate cropland/forestland** to grow crops it doesn't actually need to
* `preloop.gms:34-35` already applies the negative sign, so `V03InpTotTransf.L` reads out positive (Mtoe > 0 means the LQD transformation path consumes BMSWAS)

Unit conversion: Mtoe/yr → EJ/yr (× 0.041868); label is written as `"Primary Energy Production|Biomass|Energy Crops (EJ/yr)"` to match MAgPIE's expected REMIND variable name.

### 2.3 How N2O and CH4 prices are computed

OPEN-PROM has only a single exogenous carbon price `VmCarVal[,"TRADE",]` (unit US$2015/t CO2); there are no separate N2O or CH4 prices. But MAgPIE's `c56_pollutant_prices` interface requires all three gas prices to be present (a missing variable would be treated as 0 and would distort land-use decisions).

Approach: **use AR6 GWP100 to convert the CO2 price into N2O and CH4 prices**:

```
Price|N2O = Price|Carbon × 273    (US$2017/t N2O)
Price|CH4 = Price|Carbon × 27     (US$2017/t CH4)
```

The coefficients come from `couplePromWithMagpie.R:30-32`:
```r
.GWP_N2O_AR6 <- 273
.GWP_CH4_AR6 <- 27
```

Note that these are **per tonne of gas (not per tonne of N or per tonne of CO2eq)**. MAgPIE's `getReportData` performs a further conversion on receipt (`× 44/28` for N2O-to-N, CH4 as-is), so using per-gas units on our side is correct — this is MAgPIE's receiving-side convention.

CO2 price unit conversion itself: US$2015 → US$2017 (× 1.04 deflator); label is set to `"Price|Carbon (US$2017/t CO2)"`.

Mode switch: the `nonCo2Mode` parameter accepts `"gwp"` (default) or `"zero"` (sets N2O/CH4 prices to 0). We use `"gwp"` because it reflects the assumption that "non-CO2 GHGs and CO2 are treated as equivalent under a single carbon budget"; `"zero"` is only used for debugging.

### 2.4 Forward aggregation method: OPEN-PROM 39 resCy → MAgPIE 12 h12

OPEN-PROM runs on 39 resCy regions; MAgPIE takes 12 h12 regions. The mapping is defined in `couplePromWithMagpie.R:46-48, 51`:

* `.EU28` (28 EU member-state ISO3 codes) → all mapped to `EUR`
* The remaining 11 resCy codes (CAZ, CHA, IND, JPN, LAM, MEA, NEU, OAS, REF, SSA, USA) are themselves h12 codes — 1:1 mapping

**Different variables use different aggregation functions** (see `couplePromWithMagpie.R:130-169`):

* **Bioenergy (extensive quantity)** — `.aggregateToH12_sum()`: the 28 EU-28 values are directly summed via `dimSums` → EUR; the other 11 are passed through 1:1. Physical interpretation: biomass is an additive flow quantity, so per-country amounts sum to the regional total
* **Carbon price (intensive quantity)** — `.aggregateToH12_price(price, bio)`: EU-28 → EUR uses a **bioenergy-weighted average**
  ```
  EUR_price[y] = Σ_{c∈EU28} (price[c,y] × bio[c,y]) / Σ_{c∈EU28} bio[c,y]
  ```
  When the denominator is 0, it falls back to a simple arithmetic mean `mean(price[EU28,y])` (to avoid division by zero). bio is chosen as the weight because once the price reaches MAgPIE, it affects bio-proportional decisions, so it should reflect "the carbon price behind each unit of bio"
* **N2O / CH4 price** — not aggregated independently, but derived by **multiplying the already-aggregated h12 CO2 price** by the GWP100 coefficients (§2.3), to avoid aggregating the same underlying variable twice

**Practical observation:** in OPEN-PROM the EU-28 values of `VmCarVal[.,"TRADE",.]` are identical across members within a given year (unified ETS carbon price), so the weighted average is mathematically equivalent to taking any single member — but the code uses the weighted-average form, which is the correct generic approach and does not depend on this observation.

## 3. Backward channel: MAgPIE → OPEN-PROM

### 3.1 Read and write

`coupleMagpieToProm()` reads `Prices|Bioenergy (US$2017/GJ)` from MAgPIE's `report.mif`:

1. **Unit conversion**: US$2017/GJ → k$2015/toe, i.e. × `0.96 × 41.868 / 1000`
2. **Temporal interpolation**: MAgPIE uses 5-year steps (2020, 2025, ...), OPEN-PROM uses annual steps (`YTIME = 2010..2100`); `magclass::time_interpolate` fills in with linear interpolation
3. **Spatial disaggregation**: see §3.2
4. **Broadcast to SBS**: see §3.2

Outputs two files:

* `iPrices_magpie.csv` — `$include`-d by `modules/08_Prices/legacy/input.gms:7-11` when `link2MAgPIE=on`, populating the `iPricesMagpie(allCy,SBS,YTIME)` table. Then `core/preloop.gms:54` uses `.FX` to fix `VmPriceFuelSubsecCarVal[.,SBS,"BMSWAS",.]` to MAgPIE's price, while `modules/08_Prices/legacy/equations.gms:21` uses `$(not sameas("BMSWAS",EFS))` to exclude BMSWAS from the price-recursion formula
* `iEmissions_magpie.csv` — 11 AFOLU emission variables (Emissions|CO2|Land, CH4|Land, N2O|Land, BC/CO/OC/SO2/VOC|AFOLU|Land|Fires, NH3|Land, NO2|Land, NO3-|Land). **The OPEN-PROM GAMS side does not currently `$include` this file**; it is retained per the "write it out anyway, reserve for future extension" requirement

### 3.2 Backward disaggregation method: MAgPIE 12 h12 → OPEN-PROM 39 resCy × 34 SBS

Backward is a two-step broadcast:

**Step A — Spatial disaggregation (h12 → 39 resCy)**, implemented by `.broadcastToResCy()` (`couplePromWithMagpie.R:349-367`):

* Build a reverse lookup: `h12_for[i] = EUR if resCy[i] ∈ EU28 else resCy[i]` (i.e. which h12 each resCy draws from)
* Each resCy directly inherits its parent h12's whole time series — no further splitting by country GDP / population / historical bioenergy share
* Physical consequence: all 28 EU-28 countries receive **the same EUR biomass price**; the 11 non-EU resCy codes (CAZ, CHA, IND, JPN, LAM, MEA, NEU, OAS, REF, SSA, USA) map 1:1
* Both prices and emissions (iEmissions) use this same broadcast. Variable names are preserved via `dimnames`

**Step B — Sector broadcast (39 resCy → 39 resCy × 34 SBS)**, applied to prices only:

* Read the `SBS` set from the gdx (`IS, NF, CH, BM, PP, FD, EN, TX, OE, OI, SE, AG, HOU, PC, PB, PT, PN, PA, GU, GT, GN, BU, PCH, NEN, PG, H2P, STEAMP, H2INFR, DAC, EW, LQD, SLD, GAS, CHP` — 34 in total)
* All 34 SBS of each country **receive the same biomass price** — the same value is copied 34 times into the CSV
* Reason: MAgPIE currently reports only a single aggregate `Prices|Bioenergy` variable, with no breakdown by energy end-use (power vs heat vs 2G liquid fuel), so there is no downstream information to allocate sector-specific prices
* Result dimension: `iPricesMagpie(allCy, SBS, YTIME)` = 39 × 34 × 91 = **120 666 cells**, with every group of 34 (same country, same year, all SBS) sharing the same value

**Why we don't disaggregate more finely:**

* h12 → resCy country-level splitting would require additional per-country weights (e.g. per-country biomass-price projections from the IIASA SSP database, or OPEN-PROM's own historical shares); this coupling does not introduce such external data
* SBS broadcast is a consistency requirement: MAgPIE's `Prices|Bioenergy` is a **producer-side** biomass feedstock ex-works price, while OPEN-PROM's `VmPriceFuelSubsecCarVal` is a **consumer-side** sector-specific purchase price. Strictly speaking there is a transport/processing markup between the two, but the current coupling treats them as the same price, markup = 0
* In the future, if MAgPIE's `Bioenergy|Crops` and `Bioenergy|Residues` were read as separate variables, a sector-specific weighting ("energy-crop share × crops price + residue share × residues price") could be done — but this would need to go hand-in-hand with a biomass-EF refinement on the OPEN-PROM side

### 3.3 Two CSV-format gotchas (fixed; flagged for review attention)

1. **The year columns must be bare integers** `2010,2011,...,2100` — no `y` prefix. `core/sets.gms:115`'s `ytime /%fStartHorizon%*%fEndHorizon%/` expands to plain-integer labels; a `y` prefix triggers GAMS Error 170 (domain violation)
2. **The GAMS call must include `-Idir=./data`** — `core/input.gms` uses root-relative paths like `$include "./iActv.csvr"` but the CSVs live in the `./data/` subdirectory. `start.R` passes this flag when invoking GAMS

## 4. Test record (SSP2-PkBudg650 scenario, 2026-04-23)

Latest full-pipeline run:
* OPEN-PROM root: `runs/DEV_2026-04-23_19-16-05/`
* MAgPIE output: `magpie/output/noAR_2026-04-23_19.35.46/`
* Timeline: round-1 started 19:16, MAgPIE started 19:35 (≈19 min), MAgPIE ended ≈20:12 (≈37 min), round-2 started 20:14:56, ended 20:33 (≈18 min). Total pipeline ≈77 min

### 4.1 End-to-end integrity

* round-2 `modelstat.txt` = **6006 lines (= 3003 country-year solves × 2 duplicated writes), all Model Status 2.00 (locally optimal), 0 non-optimal**
* round-2 is **byte-identical** to the previous pipeline's `runs/DEV_2026-04-23_16-38-02/blabla.gdx` on y2100 `V03ConsGrssInl[BMSWAS]` (Δ = 0.00%), and MAgPIE's `report.mif` is likewise byte-identical — confirming pipeline determinism
* GAMS actual value `iPricesMagpie[DEU,y2030,IS] = 0.245316` exactly matches the corresponding cell in `iPrices_magpie.csv`, confirming the csv→GAMS read is correct

### 4.2 Coupling impact on OPEN-PROM (round-1 vs round-2)

The round-1 reference comes from `runs/DEV_2026-04-23_16-38-02/blabla_before_magpie_couple.gdx` (a round-1 snapshot retained from the previous full pipeline; the current task 7 flow reuses a single folder, so round-2 overwrites round-1's `blabla.gdx` and the NEW test's round-1 has been overwritten. Since round-1 under `link2MAgPIE=off` does not read `iPrices_magpie.csv` and is fully deterministic, using the retained round-1 snapshot for comparison is valid):

| Metric | y2030 | y2050 | y2100 |
|---|---:|---:|---:|
| `V03ConsGrssInl[BMSWAS]` round-1 (Mtoe/yr) | 1203.2 | 1292.6 | 2269.2 |
| `V03ConsGrssInl[BMSWAS]` round-2 (Mtoe/yr) | 1230.4 | 1397.9 | 2647.4 |
| **Δ Biomass consumption** | **+2.3%** | **+8.1%** | **+16.7%** |
| Total CO2 round-1 (Mt CO2/yr, supply+demand) | 32414.4 | 29851.8 | 25281.8 |
| Total CO2 round-2 (Mt CO2/yr) | 32572.3 | 29770.0 | 25078.7 |
| **Δ CO2 emissions** | **+0.49%** | **−0.27%** | **−0.80%** |

**Direction matches expectations:** MAgPIE returns `Prices|Bioenergy` values that are cheaper than OPEN-PROM's defaults in most regions (EUR y2030 7.35 US\$2017/GJ, CHA y2030 7.47, USA y2030 6.69, vs OPEN-PROM's higher default BMSWAS price). `preloop.gms:54` fixes the BMSWAS price to this lower value → OPEN-PROM burns more biomass and pushes out fossil fuels → combustion-side CO2 falls slightly.

**Are the magnitudes reasonable?**
* +16.7% biomass at y2100 is within the **typical response range** for a "BMSWAS-only price substitution" style coupling. OPEN-PROM's fuel switching is driven by `VmPriceFuelSubsecCarVal`; since the prices of other fuels are unchanged, the magnitude is consistent with the elasticity assumptions
* Only −0.80% CO2 at y2100 — small but reasonable. Reasons:
  * The coupling only changes the BMSWAS **price** — it does not change the biomass availability ceiling or CCS capacity
  * The scenario itself is the stringent PkBudg650 constraint, already deep decarbonization (y2100 is 22% below y2030), so marginal substitution headroom is limited
  * Biomass itself has combustion EF = 0 in OPEN-PROM (all `BMSWAS` combustion EFs in `core/input.gms:84-97` are zero, with 4.17 kgCO2/kgoe added only on the BECCS CCS capture side). So burning more biomass does not directly add CO2 on-book, but the fossil it displaces does reduce CO2
* +0.49% CO2 at y2030 looks counter-intuitive, but y2030 biomass only +2.3%; the CO2 +0.49% comes mostly from second-order rebalancing in other sectors during re-optimization, and the magnitude is within solver tolerance (< 1%)

### 4.3 A forward-channel limitation discovered (to be addressed in a future iteration)

Querying `V03InpTotTransf[,"LQD","BMSWAS",.]` in the round-1 gdx (i.e. the 2G biomass feedstock we pass to MAgPIE): **it is essentially zero in almost all regions**, with only SSA (0.009 Mtoe/yr at y2100), MEA, and SVN having tiny non-zero values. As a result, `Primary Energy Production|Biomass|Energy Crops` in `openprom_coupling.mif` is **all zeros across all 12 h12 regions for all 91 years**.

Implication:
* **MAgPIE's `c60_2ndgen_biodem = coupling` effectively receives a zero bio-demand signal** — land use is not pushed to expand 2G plantation areas by OPEN-PROM's energy scenario
* The carbon-price signal `c56_pollutant_prices = coupling` is transmitted normally (EUR y2030 = 26.56 US\$2017/t CO2), so MAgPIE still responds to GHG prices and adjusts AFOLU emissions; it is only the bio-demand-driven pathway that is not active

The cause is that OPEN-PROM's `V03InpTotTransf[,"LQD","BMSWAS",.]` (BMSWAS feedstock on the liquid-biofuel pathway) is itself near-zero under SSP2-PkBudg650 — in this scenario OPEN-PROM consumes biomass mainly through `PG.BMSWAS` (power generation), `H2P.BMSWAS` (hydrogen) and `STEAMP.BMSWAS` (steam/heat), not through the LQD pathway. To strictly align with 2G lignocellulosic, only `LQD.BMSWAS` matches in source structure; the other pathways do not (see §2.2).

**Possible improvement directions (need scoping):**
* Investigate why `V03InpTotTransf[LQD,BMSWAS]` is ≈0 — is the SSP2-PkBudg650 scenario genuinely not using 2G liquid fuel, or is an internal OPEN-PROM constraint pinning it to 0?
* If 2G liquid fuel is scenario-wise negligible, the practical meaning of the bio forward channel is to transmit a "definite zero" (so that MAgPIE does not over-allocate cropland to energy crops when OPEN-PROM does not need any 2G). This is itself a valid form of coupling
* To give the bio signal a meaningful magnitude, one would need to **redefine the source variable for the forward bio channel** — e.g. sum `PG.BMSWAS + H2P.BMSWAS + STEAMP.BMSWAS`. But this must be paired with a MAgPIE-side interface change that separates residue from crop streams; otherwise, per the argument in §2.2, sending the aggregate lump would cause MAgPIE to over-allocate cropland/forestland (because `c60_2ndgen_biodem` assumes what it receives is 2G lignocellulosic demand)

### 4.4 Summary

* The pipeline runs end-to-end; round-2 is fully locally optimal; runs are stable and reproducible
* The backward channel (MAgPIE → OPEN-PROM biomass price) **works as expected**; OPEN-PROM responds correctly with reasonable direction and magnitude
* The forward CO2 price channel works as expected
* The forward bio-quantity channel currently transmits ~0 — this is not a bug, it is a consequence of the current scenario + variable choice. If a non-trivial bio signal is desired in the future, the source-variable choice from §2.2 needs to be revisited (or we accept the semantics of "OPEN-PROM explicitly tells MAgPIE that no 2G is needed")
