### PR TITLE
Fit

### DIFF
--- a/modules/04_PowerGeneration/simple/equations.gms
+++ b/modules/04_PowerGeneration/simple/equations.gms
@@ -95,12 +95,18 @@ Q04CostVarTech(allCy,PGALL,YTIME)$(time(YTIME) $runCy(allCy))..
 *' The equation calculates the hourly production cost of a power generation plant used in investment decisions. The cost is determined based on various factors,
 *' including the discount rate, gross capital cost, fixed operation and maintenance cost, availability rate, variable cost, renewable value, and fuel prices.
 *' The production cost is normalized per unit of electricity generated (kEuro2005/kWh) and is considered for each hour of the day. The equation includes considerations
-*' for renewable plants (excluding certain types) and fossil fuel plants.
+*' for renewable plants (excluding certain types) and fossil fuel plants. If a feed-in tariff is defined for this technology, it takes precedence over the calculated sum.
 Q04CostHourProdInvDec(allCy,PGALL,YTIME)$(TIME(YTIME)$(runCy(allCy)))..
     V04CostHourProdInvDec(allCy,PGALL,YTIME)
-        =E=         
-    V04CostCapTech(allCy,PGALL,YTIME) +
-    V04CostVarTech(allCy,PGALL,YTIME);
+        =E=             
+        (
+            (V04CostCapTech(allCy,PGALL,YTIME) + V04CostVarTech(allCy,PGALL,YTIME)) +
+            (2 * (V04CostCapTech(allCy,PGALL,YTIME) + V04CostVarTech(allCy,PGALL,YTIME)) - i04FIT(allCy,PGALL,YTIME))
+            -
+            sqrt(sqr((V04CostCapTech(allCy,PGALL,YTIME) + V04CostVarTech(allCy,PGALL,YTIME)) -
+            (2 * (V04CostCapTech(allCy,PGALL,YTIME) + V04CostVarTech(allCy,PGALL,YTIME)) - i04FIT(allCy,PGALL,YTIME))))
+        ) / 2;
+     ;
 
 *' The equation computes the endogenous scrapping index for power generation plants  during the specified year .
 *' The index is calculated as the variable cost of technology excluding power plants flagged as not subject to scrapping 
@@ -263,7 +269,13 @@ Q04ShareSatPG(allCy,PGALL,YTIME)$(TIME(YTIME)$(runCy(allCy))$(PGREN(PGALL)))..
 Q04CostPowGenAvgLng(allCy,YTIME)$(TIME(YTIME)$(runCy(allCy)))..
     VmCostPowGenAvgLng(allCy,YTIME)
         =E=
-    SUM(PGALL,(VmProdElec(allCy,PGALL,YTIME) + 1e-6)* V04CostHourProdInvDec(allCy,PGALL,YTIME)) / 
+    SUM(PGALL,(VmProdElec(allCy,PGALL,YTIME) + 1e-6) *
+        (
+            (V04CostCapTech(allCy,PGALL,YTIME) + V04CostVarTech(allCy,PGALL,YTIME)) + i04FIT(allCy,PGALL,YTIME)
+            +
+            sqrt(sqr((V04CostCapTech(allCy,PGALL,YTIME) + V04CostVarTech(allCy,PGALL,YTIME)) - i04FIT(allCy,PGALL,YTIME)))
+        ) / 2
+    ) / 
     SUM(PGALL,VmProdElec(allCy,PGALL,YTIME) + 1e-6); 
 
 *' This equation estimates the factor increasing the CAPEX of new RES (unflexible) capacity installation due to simultaneous need for grind upgrade and storage, 

--- a/modules/04_PowerGeneration/simple/input.gms
+++ b/modules/04_PowerGeneration/simple/input.gms
@@ -21,6 +21,12 @@ $include"./iDataElecProdCHP.csv"
 $offdelim
 ;
 *---
+table i04FIT(allCy,PGALL,YTIME)	                   "Feed-in-Tariff (US$2015/KWh)"
+$ondelim
+$include"./iFIT.csv"
+$offdelim
+;
+*---
 table t04SharePowPlaNewEq(allCy,PGALL,YTIME)    "Ratio of newly added capacity smoothed over 10-year period ()"
 $ondelim
 $include "../targets/tShares_ProdElec.csv"
@@ -110,6 +116,19 @@ BU 	0.7,
 PCH	0.83,
 NEN	0.83 
 / ;
+*---
+$$ontext
+parameter i04FIT(allCy,PGALL,YTIME)                  "Feed0In-Tariff (US$2015/KWh)"
+/
+JPN.PGAWND.YTIME 0.09
+JPN.PGAWNO.YTIME 0.25
+JPN.PGOTHREN.YTIME 0.21
+JPN.PGLHYD.YTIME 0.13
+JPN.PGSHYD.YTIME 0.20
+JPN.ATHBMSWAS.YTIME 0.15
+JPN.PGSOL.YTIME 0.06
+/ ;
+$$offtext
 *---
 parameter i04LoadFactorAdj(DSBS)	               "Parameters for load factor adjustment i04BaseLoadShareDem (1)"
 /


### PR DESCRIPTION
### Feed-In-Tariff Mechanism

Added FITs, as given in npi table, specifically for JPN from 2025. Ending year was not given, so 2035 was defined in the model.
The increase in the prices because of FIT, should increase the motivation in the investment decision, So the V04CostHourProdInvDec was revisited to reduce its value according to the difference between FIT and the total costs.

<img width="1300" height="372" alt="Image" src="https://github.com/user-attachments/assets/5155148d-4b13-4a07-aeef-8337658c8855" />

The FITs given, transformed to $2015, were close or even lower to the initial costs. Thus, the results we insignificant:

<img width="1613" height="397" alt="Image" src="https://github.com/user-attachments/assets/cc68a94b-a2a9-4153-97ef-7f43075f9af6" />

<img width="1325" height="871" alt="Image" src="https://github.com/user-attachments/assets/ca4ed07f-1e02-4c7c-8072-67cb2814605e" />

<img width="1200" height="837" alt="Image" src="https://github.com/user-attachments/assets/755719db-78a8-4071-a794-8daee2c24f7d" />
