### PR TITLE
Refactor carbon price handling and complimentary carbon price path designer

### DIFF
--- a/scripts/tasks/findCarbonPrice.R
+++ b/scripts/tasks/findCarbonPrice.R
@@ -3,61 +3,61 @@
 # ============================================================
 
 # This script calibrates carbon prices in the OPEN-PROM model so that simulated
-# emissions match specified target levels (e.g., Mt CO2 or Mt CO2-equivalent)
-# for selected regions or for an aggregated region such as EU27 or the world.
+# emissions match user-defined budget targets for any combination of regions,
+# the EU27 block, or the entire world.
 #
-# The script perturbs the carbon price trajectory contained in `data/iEnvPolicies.csv`
+# The script perturbs the carbon price trajectory in `data/iEnvPolicies.csv`
 # by applying a scalar adjustment factor (alpha) and repeatedly runs OPEN-PROM
-# through GAMS until the resulting emissions match a user-defined target.
+# through GAMS until the resulting emissions converge to each target.
 #
 # Core workflow:
 # 1) Read the baseline policy file (`iEnvPolicies.csv`).
-# 2) Multiply carbon price values from a chosen start year onward by (1 + alpha).
+# 2) Multiply carbon price values from `changeCarbonPriceFromYear` onward by (1 + alpha).
 # 3) Execute OPEN-PROM via GAMS.
-# 4) Post-process model outputs using `postprom`/`gdx` to compute emissions.
+# 4) Post-process model outputs via `reportEmissions` (postprom/gdx) to extract
+#    the tracked emissions variable, scaled to the unit of the budget targets.
 # 5) Iteratively adjust alpha until emissions meet the target using:
 #      • automatic bracketing around a seed alpha
-#      • bisection root-finding to converge to the target emissions level
+#      • bisection root-finding to converge to the target
+# 6) Repeat sequentially for each entry in `targetList`, carrying forward the
+#    updated policy file so each region builds on previously optimized prices.
 #
-# Key features:
-# • Supports sequential optimization for multiple regions (one after another).
-# • Can run in regional mode (specific region codes) or global/EU mode.
-# • Automatically modifies the `main.gms` file to set the target region.
-# • Handles CO2 or CO2-equivalent emissions depending on `flagCO2eq`.
-# • Calculates GHG totals using IPCC AR4 Global Warming Potential factors.
-# • Maintains automatic backups of policy input files to allow rollback.
-# • Writes updated policy files once optimization converges.
-# • Logs all runs, iterations, and errors to `Carbon_price_optimization.log`.
+# Solve modes (controlled by keys in `targetList`):
+# • Single region  – alpha applied to that region’s rows only; fCountries in
+#                    main.gms is updated so OPEN-PROM solves only that region.
+# • "EU27"         – alpha applied identically to all 27 EU member rows, which
+#                    share a single carbon price; emissions summed across members.
+#                    main.gms is NOT modified (all regions must run).
+# • "WORLD"        – alpha applied to all region rows; emissions summed globally.
+#                    main.gms is NOT modified.
+#
+# Emissions variable:
+# • Controlled by `emissionsVariable` and `emissionsScale` in the Run section.
+# • Any variable name returned by reportEmissions() can be used.
+# • `emissionsScale` converts the raw variable unit to match the budget targets.
 #
 # Dependencies:
-#   data.table, dplyr, tidyr, gdx, postprom, mrprom, stringr
+#   data.table, dplyr, tidyr, gdx, postprom, mrprom, quitte, stringr
 #   and a working GAMS installation accessible via the `gams` command.
 #
 # Typical usage:
-# 1) Define emissions targets (e.g., in `targetList` for regional runs
-#    or `globalParams` for EU/world runs).
-# 2) Configure key parameters:
-#      • `selectedYear` – year used for emissions matching
-#      • `changeCarbonPriceFromYear` – first year carbon prices are modified
-#      • `flagCO2eq` – toggle between CO2 or CO2-equivalent emissions
-# 3) Ensure `data/iEnvPolicies.csv` and `main.gms` exist.
-# 4) Run the script. It will:
-#      • probe emissions responses,
-#      • automatically bracket a valid alpha range,
-#      • solve for the optimal alpha via bisection,
-#      • update carbon prices accordingly.
+# 1) Set `emissionsVariable` and `emissionsScale` to match the budget unit.
+# 2) Set `selectedYear` and `changeCarbonPriceFromYear`.
+# 3) Populate `targetList` with region keys and budget values.
+#    Use "EU27" for the EU block and "WORLD" for a global run.
+# 4) Ensure `data/iEnvPolicies.csv` and `main.gms` exist and run the script.
 #
 # Output:
-# • Updated carbon price trajectory written to `data/iEnvPolicies_updated.csv`
-# • Timestamped backups of policy files
-# • Execution log stored in `Carbon_price_optimization.log`
+# • Updated carbon price trajectory written to `data/iEnvPolicies.csv` and
+#   `data/iEnvPolicies_updated.csv` (plus a timestamped copy).
+# • Execution log stored in `Carbon_price_optimization.log`.
 #
 # Notes:
 # • Alpha represents a proportional change in carbon prices:
 #       new_price = old_price * (1 + alpha)
-# • Alpha < 0 decreases prices, alpha > 0 increases prices.
-# • Sequential runs update the policy file cumulatively so that
-#   each region’s optimization builds on previously optimized regions.
+# • Alpha < 0 decreases prices; alpha > 0 increases prices.
+# • Sequential runs update the policy file cumulatively so each region’s
+#   optimization builds on the prices already set for previous regions.
 
 suppressPackageStartupMessages({
   library(data.table)
@@ -66,6 +66,7 @@ suppressPackageStartupMessages({
   library(gdx)
   library(postprom)
   library(mrprom)
+  library(quitte)   # provides interpolate_missing_periods used by reportEmissions
   library(stringr)
 })
 
@@ -84,7 +85,7 @@ if (file.exists(inputCsvPath) && !file.exists(backupCsvPath)) {
 }
 
 # ----------------------------
-# IO helpers
+# IO helpers: read/write iEnvPolicies.csv
 # ----------------------------
 readEnvPolicies <- function(csvPath = inputCsvPath) {
   envWide <- data.table::fread(csvPath, na.strings = c("NA", "", "NaN"), header = TRUE)
@@ -101,16 +102,17 @@ readEnvPolicies <- function(csvPath = inputCsvPath) {
 
 applyAlpha <- function(envWide, yearCols, alpha, targetRegion) {
   x <- data.table::copy(envWide)
-  
-  # Identify only year columns >= 2025
+
   yearColsFuture <- yearCols[as.integer(yearCols) >= changeCarbonPriceFromYear]
-  
+
   if (is.null(targetRegion)) {
-    # --- GLOBAL MODE: Apply to ALL regions ---
-    # Formula: new = old + (alpha * old)
+    # GLOBAL: apply to all regions
     x[, (yearColsFuture) := lapply(.SD, function(col) col * (1 + alpha)), .SDcols = yearColsFuture]
+  } else if (targetRegion == "EU27") {
+    # EU27: apply the same alpha to all 27 member rows (they share one price)
+    x[region %in% EU27_REGIONS, (yearColsFuture) := lapply(.SD, function(col) col * (1 + alpha)), .SDcols = yearColsFuture]
   } else {
-    # --- REGIONAL MODE: Apply to specific region only ---
+    # Single region
     x[region == targetRegion, (yearColsFuture) := lapply(.SD, function(col) col * (1 + alpha)), .SDcols = yearColsFuture]
   }
   x
@@ -134,7 +136,7 @@ writeFinalPolicyFiles <- function(envWide, yearCols, alphaFinal, region,
 }
 
 # ----------------------------
-# Simulator wrapper (fixed defaults)
+# Simulator wrapper: runs GAMS and returns success/failure
 # ----------------------------
 run_gams <- function(gms = "main.gms",
                      args = GAMSCmdArgs,
@@ -158,7 +160,7 @@ run_gams <- function(gms = "main.gms",
   }
 }
 
-# Returns cumulative CO2 (Gt) for a given alpha
+# Runs OPEN-PROM for a given alpha and returns the tracked emissions value.
 emissionsOPENPROM <- function(envWide, yearCols, alpha, targetRegion, targetYear,
                               dataDir = "data",
                               gms = "main.gms",
@@ -174,10 +176,10 @@ emissionsOPENPROM <- function(envWide, yearCols, alpha, targetRegion, targetYear
   ok <- run_gams(gms = gms, args = gamsArgs, log = log, echo_on_success = echo_on_success)
   if (!ok) stop("OPEN-PROM run failed for alpha=", alpha)
 
-  # Post-process emissions via postprom
+  # Read GDX output and extract emissions via postprom
   regions <- readGDX(file.path(workDir, "blabla.gdx"), "runCYL")
   years   <- paste0("y", c(2010:2020, as.character(readGDX(file.path(workDir, "blabla.gdx"), "an"))))
-  # Send text output to the void (nullfile) and suppress messages
+  # Suppress console noise from reportEmissions
   utils::capture.output({
       suppressMessages({
         suppressWarnings({
@@ -187,40 +189,27 @@ emissionsOPENPROM <- function(envWide, yearCols, alpha, targetRegion, targetYear
     }, file = nullfile())
 
 
-  items <- getItems(emissions, 3)
-  keep  <- items[!grepl("^Price|^Activity growth rate", items)]
-  addRegionGLO <- dimSums(emissions[, , keep], 1, na.rm = TRUE)
-  getItems(addRegionGLO, 1) <- "World"
-  emissionsWorld <- mbind(emissions, addRegionGLO)
+  CO2cum <- extractEmissions(emissions)
 
-  # Calculate GHG
-  CO2eq <- calculateGhg(emissions)
-
-  if (!is.null(targetRegion)) {
-    # Specific Region Case
-    val <- CO2eq[targetRegion, targetYear, ]
+  if (is.null(targetRegion)) {
+    # GLOBAL: sum all regions
+    val <- dimSums(CO2cum, dim = 1)[, targetYear, ]
+  } else if (targetRegion == "EU27") {
+    # EU27: sum over member regions present in the GDX output
+    eu27present <- EU27_REGIONS[EU27_REGIONS %in% getRegions(CO2cum)]
+    val <- dimSums(CO2cum[eu27present, , ], dim = 1)[, targetYear, ]
   } else {
-    # ΕU Case: Sum over all regions (dim 1)
-    # --- Filter for EU27 Regions ---
-    regionMapping <- toolGetMapping(name = "EU28.csv", type = "regional", where = "mrprom")
-    regionsEu27 <- regionMapping$ISO3.Code[regionMapping$ISO3.Code != "GBR"]
-    dataMagpieEu27 <- CO2eq[getRegions(CO2eq) %in% regionsEu27, , ]
-
-    # Global Case: Sum over all regions (dim 1)
-    val <- dimSums(dataMagpieEu27, dim = 1)[, targetYear, ]
+    # Single region
+    val <- CO2cum[targetRegion, targetYear, ]
   }
   
-  # Always use Mt to be consistent for countries and regions
   as.numeric(val)
-
-  #as.numeric(emissionsWorld["World", 2100, "Emissions|CO2|Cumulated.Gt CO2"])
 }
 
 # ----------------------------
-# Seeding, bracketing, solving
+# Seeding, bracketing, bisection solver
 # ----------------------------
 
- # linear interpolation
 alphaSeedLinear <- function(alpha0, E0, alphar, Er, Etarget, warn = TRUE, stopIfOutside = FALSE) {
   stopifnot(alphar != alpha0, Er != E0)  # avoid divide-by-zero
   # check Etarget range
@@ -273,7 +262,7 @@ findAlphaForBudget <- function(envWide, yearCols, budgetTarget,
                                tolAlphaRel = 1e-3, tolEmisAbs = 1e-3,
                                maxIter = 60, verbose = TRUE, writeFinalCsv = TRUE) {
 
-  # If we dont run auto-seed, then we need to now the emissions in the lower and higher bounds.
+  # Evaluate bounds if not already provided by autoBracketFromSeed.
   if (is.null(eLow))  eLow  <- emissionsOPENPROM(envWide, yearCols, lowerAlpha, targetRegion, targetYear)
   if (is.null(eHigh)) eHigh <- emissionsOPENPROM(envWide, yearCols, upperAlpha, targetRegion, targetYear)
 
@@ -290,18 +279,37 @@ findAlphaForBudget <- function(envWide, yearCols, budgetTarget,
   aL <- lowerAlpha; aU <- upperAlpha
   emisL <- eLow;     emisU <- eHigh
   it <- 0
+  # Illinois flag: tracks which side was updated twice in a row so we can
+  # halve that side's emission value, keeping superlinear convergence guaranteed.
+  lastSide <- NA
 
   while (it < maxIter) {
     it <- it + 1
-    aM <- 0.5 * (aL + aU)
+
+    # Illinois / false-position step: interpolate linearly toward the target.
+    # Much faster than bisection (superlinear convergence) because it uses the
+    # gradient information already available from the two bracket endpoints.
+    # Falls back to bisection midpoint if interpolation lands outside the bracket.
+    aM <- aL + (budgetTarget - emisL) * (aU - aL) / (emisU - emisL)
+    aM <- max(aL, min(aU, aM))   # clamp to bracket for safety
+
     emisM <- emissionsOPENPROM(envWide, yearCols, aM, targetRegion, targetYear)
     if (verbose) message(sprintf("Iter %02d: aM=%.6f -> E=%.6f (target=%.6f)", it, aM, emisM, budgetTarget))
 
-    if (emisM > budgetTarget) { aL <- aM; emisL <- emisM } else { aU <- aM; emisU <- emisM }
-    if ((abs(aU - aL) / max(1.0, aM) < tolAlphaRel) || (abs(emisM - budgetTarget) < tolEmisAbs)) {
+    if (abs(emisM - budgetTarget) < tolEmisAbs || abs(aU - aL) / max(1.0, abs(aM)) < tolAlphaRel) {
       if (verbose) message("Converged.")
       if (writeFinalCsv) writeFinalPolicyFiles(envWide, yearCols, aU, targetRegion)
       return(list(alpha = aU, emissions = emisU, converged = TRUE, iters = it))
+    }
+
+    if (emisM > budgetTarget) {
+      # Left side (high-emission) moves up
+      if (identical(lastSide, "L")) emisU <- emisU / 2   # Illinois correction
+      aL <- aM; emisL <- emisM; lastSide <- "L"
+    } else {
+      # Right side (low-emission) moves down
+      if (identical(lastSide, "U")) emisL <- emisL / 2   # Illinois correction
+      aU <- aM; emisU <- emisM; lastSide <- "U"
     }
   }
 
@@ -312,224 +320,125 @@ findAlphaForBudget <- function(envWide, yearCols, budgetTarget,
 configureGamsFile <- function(gmsPath, targetRegion) {
   lines <- readLines(gmsPath, warn = FALSE)
   
-  # Find the line with "$setGlobal fCountries" (ignoring spaces/case)
   idx <- grep("fCountries", lines, ignore.case = TRUE)
-  
   if (length(idx) > 0) {
-    # Replace that specific line completely
     lines[idx[1]] <- paste0("$setGlobal fCountries '", targetRegion, "'")
-    message(sprintf("  -> Updated fCountries to '%s'", targetRegion))
-    
-    # Save the file
     writeLines(lines, gmsPath)
+    message(sprintf("  -> Updated fCountries to '%s'", targetRegion))
   } else {
-    warning("Could not find 'fCountries' in main.gms")
+    warning("Could not find '$setGlobal fCountries' in main.gms")
   }
 }
-# --- Helper Function: Get CO2 Equivalent Factor ---
-getCo2EqFactor <- function(varName) {
-  # Define GWP Factors (AR4 100-year values standard for reporting)
-  gwpMap <- c(
-    "CH4"        = 25,
-    "N2O"        = 298,
-    "SF6"        = 22800,
-    "HFC125"     = 3500,
-    "HFC134a"    = 1430,
-    "HFC143a"    = 4470,
-    "HFC152a"    = 124,
-    "HFC227ea"   = 3220,
-    "HFC23"      = 14800,
-    "HFC32"      = 675,
-    "HFC43-10"   = 1640,
-    "HFC245ca"   = 693,
-    "HFC-236fa"  = 9810,
-    "PFC"        = 7390,
-    "CF4"        = 7390,
-    "C2F6"       = 12200,
-    "C6F14"      = 9300
-  )
-  
-  cleanName <- sub("(\\s*\\(.*\\)|\\.[^.]*)$", "", varName)
-  
-  if (grepl("CH4", cleanName)) {
-    return(gwpMap[["CH4"]])
-  } else if (grepl("N2O", cleanName)) {
-    return(gwpMap[["N2O"]] / 1000)
-  } else {
-    gasLeaf <- sub(".*\\|", "", cleanName)
-    if (gasLeaf %in% names(gwpMap)) {
-      return(gwpMap[[gasLeaf]] / 1000)
-    } else {
-      warning(paste("GWP not found for:", varName))
-      return(0)
-    }
-  }
-}
-#' Calculate GHG Emissions (Mt CO2eq) from a magpie object
-calculateGhg <- function(dataMagpie) {
-
-  # --- Apply Conversion ---
-  allVars <- getNames(dataMagpie)
-  targetVars <- grep("Emissions\\|", allVars, value = TRUE)
-  
-  totalCo2Eq <- NULL
-  
-  for (var in targetVars) {
-    factor <- getCo2EqFactor(var)
-    
-    if (factor != 0) {
-      currentGas <- dataMagpie[, , var] * factor
-      totalCo2Eq <- mbind(totalCo2Eq, currentGas)
-    }
-  }
-  
-  # Combine with Energy CO2
-  if (flagCO2eq) {
-    #emissions <- mbind(totalCo2Eq, dataMagpie[, , "Emissions|CO2|Energy and Industrial Processes.Mt CO2/yr"])
-    #emissions <- mbind(totalCo2Eq, dataMagpie[, , "Emissions|CO2.Mt CO2/yr"])
-    emissions <- dataMagpie[, , "Emissions|Kyoto Gases.Mt CO2-equiv/yr"]
-  } else {
-    #emissions <- dataMagpie[, , "Emissions|CO2|Energy and Industrial Processes.Mt CO2/yr"]
-    emissions <- dataMagpie[, , "Emissions|CO2.Mt CO2/yr"]
-  }
-
-  # --- Exclude Specific Variables (Fit for 55 logic) ---
-  # emissions <- emissions[, , setdiff(getNames(emissions),
-  #                                    c("Emissions|NOx|AFOLU. Mt NH3/yr",
-  #                                      "Emissions|CH4|AFOLU|Land. Mt CH4/yr",
-  #                                      "Emissions|N2O|AFOLU|Land. kt N2O/yr"))]
-  
-  # --- Aggregation ---
-  emissionsCO2eq <- dimSums(emissions, dim = 3)
-  getNames(emissionsCO2eq) <- "Emissions. Mt CO2-equiv/yr"
-
-  return(emissionsCO2eq)
+extractEmissions <- function(dataMagpie) {
+  # Variable and scale are set in the Run section below.
+  # emissionsVariable: name of the variable in the reportEmissions magpie object
+  # emissionsScale:    multiplier to convert to the same unit as the budget targets
+  emissions <- dataMagpie[, , emissionsVariable] * emissionsScale
+  emissionsMt <- dimSums(emissions, dim = 3)
+  getNames(emissionsMt) <- emissionsVariable
+  emissionsMt
 }
 
 # ----------------------------
 # Run
 # ----------------------------
 start_time <- Sys.time()
-GAMSCmdArgs <- c("--DevMode=0", "--GenerateInput=off", "lo=4", "idir=./data")
-selectedYear <- 2050
-changeCarbonPriceFromYear <- 2031
-flagCO2eq <- TRUE
+GAMSCmdArgs <- c("--DevMode=0", "--GenerateInput=off", "lo=4", "idir=./data", "--CountrySolveMode=parallel")
+selectedYear <- 2100
+changeCarbonPriceFromYear <- 2026
 
-# ---------------------------------------------------------
-# CASE A: Specific Regions
-# targetConditionalMtCO2e MtCO2e/yr
-# targetList <- list(
-#    "CAZ" = 780.6,
-#    #"CHA" = 14373,
-#    "GBR" = 260.3,
-#    #"IND" = 4816,
-#    "JPN" = 760.32,
-#    #"LAM" = 3886,
-#    #"MEA" = 2164.6,
-#    #"NEU" = 832.1,
-#    "OAS" = 5292.7,
-#    "REF" = 3668
-#    #"SSA" = 832.1
-# )
-# targetConditionalMtCO2 MtCO2/yr - ONLY CO2
-# targetList <- list(
-#   "CAZ" = 585,
-#   "CHA" = 10780,
-#   "GBR" = 195,
-#   "IND" = 3612,
-#   "JPN" = 570,
-#   "LAM" = 2915,
-#   "MEA" = 1623,
-#   "NEU" = 624,
-#   "OAS" = 3970,
-#   "REF" = 2752,
-#   "SSA" = 1735
-# )
-# targetConditionalMtCO2 MtCO2/yr - ONLY Emissions|CO2|Energy & Industrial Processes. MtCO2/yr
-# targetList <- list(
-#   "CAZ" = 777,
-#   "CHA" = 11252,
-#   "GBR" = 195,
-#   "IND" = 3592,
-#   "JPN" = 644,
-#   "LAM" = 4177,
-#   "MEA" = 1653,
-#   "NEU" = 719,
-#   "OAS" = 3583,
-#   "REF" = 3813,
-#   "SSA" = 2113
-# )
+# --- Emissions variable to track ---
+# Set emissionsVariable to any variable name returned by reportEmissions().
+# Set emissionsScale so that after multiplication the unit matches your budget targets.
+#
+# Common choices:
+#   "Emissions|CO2|Cumulated.Gt CO2"          * 1000  -> Mt CO2  (cumulated)
+#   "Emissions|CO2.Mt CO2/yr"                 * 1     -> Mt CO2/yr
+#   "Emissions|Kyoto Gases.Mt CO2-equiv/yr"   * 1     -> Mt CO2-equiv/yr
+emissionsVariable <- "Emissions|CO2|Cumulated.Gt CO2"
+emissionsScale    <- 1000   # Gt -> Mt
 
-# CASE B: No Target Regions (Empty List) -> Implies EU27 Run
-targetList <- NULL
-#globalParams <- 1750 # EU-27 target 2030 in MtCO2/yr - ONLY CO2
-#globalParams <- 2250  # EU-27 target 2030 in MtCO2e/yr 
-#globalParams <- 0  # EU-27 target 2030 in MtCO2e/yr 
-globalParams <- 0  # World target 2080 in MtCO2e/yr
+# EU27 member regions — share a single carbon price in iEnvPolicies.csv.
+# Never optimised individually; always solved as one aggregated group.
+EU27_REGIONS <- c("AUT","BEL","BGR","CYP","CZE","DEU","DNK","ESP","EST",
+                   "FIN","FRA","GRC","HRV","HUN","IRL","ITA","LTU","LUX",
+                   "LVA","MLT","NLD","POL","PRT","ROU","SVK","SVN","SWE")
 
-# LOGGING SETUP
+# --- Target list ---
+# Each entry is a named budget in the unit of emissionsVariable * emissionsScale.
+# Special keys:
+#   "EU27"  -> shared alpha applied to all 27 EU member rows; emissions summed over members.
+#   "WORLD" -> alpha applied to all region rows; emissions summed globally.
+# Any other key must match a region code in iEnvPolicies.csv.
+# Comment out any entry to skip that region in this run.
+#
+# Current unit: cumulated Mt CO2  (Emissions|CO2|Cumulated.Gt CO2 * 1000)
+targetList <- list(
+  #"WORLD" = 1257571,  # optional: comment out to skip world run
+  "EU27"  = 92917,    # sum of all 27 EU member budgets
+  "CAZ"   = 22517,
+  "CHA"   = 307728,
+  "GBR"   = 14692,
+  "IND"   = 223711,
+  "JPN"   = 29285,
+  "LAM"   = 117008,
+  "MEA"   = 102029,
+  "NEU"   = 22276,
+  "OAS"   = 220646,
+  "REF"   = 64216,
+  "SSA"   = 175989,
+  "USA"   = 100855
+)
+
 logFilePath <- "Carbon_price_optimization.log"
 file.create(logFilePath)
 logCon <- file(logFilePath, open = "a")
-# ---------------------------------------------------------
 
 envData <- readEnvPolicies(inputCsvPath)
 currentEnvWide <- envData$envWide
 yearCols       <- envData$yearCols
 
-# Backup original state
+if (length(targetList) == 0) stop("targetList is empty. Add at least one region or 'WORLD' entry.")
+
 if (file.exists(inputCsvPath)) file.copy(inputCsvPath, backupCsvPath, overwrite = TRUE)
 
-# PREPARE THE LOOP LIST
-if (length(targetList) > 0) {
-  # We have specific countries
-  runQueue <- targetList
-  message("Mode: Sequential Regional Optimization")
-} else {
-  # We have NO specific countries -> Global Mode
-  # We use "NULL" as the key to signal global or EU mode to our loop
-  runQueue <- list("GLOBAL" = globalParams)
-  message("Mode: Global Optimization (No specific regions defined)")
-}
-
-# Redirect standard output and messages to the file connection
 sink(logCon, type = "output")
 sink(logCon, type = "message")
 
-# We use on.exit to ensure console comes back even if script crashes!
+# Restore console output even if the script crashes
 on.exit({
-  sink(type = "message") # Restore messages
-  sink()                 # Restore output
-  close(logCon)          # Close file
+  sink(type = "message")
+  sink()
+  close(logCon)
   message("Log redirection ended. Console restored.")
 }, add = TRUE)
 resultsLog <- list()
 
-# Countries/Regions Loop
-for (regName in names(runQueue)) {
-  
-  bg <- runQueue[[regName]]
-  
-  # Determine if this is a real region code or Global mode
-  if (regName == "GLOBAL") {
-    actualRegion <- NULL  # Pass NULL to helpers for Global
+for (regName in names(targetList)) {
+
+  bg <- targetList[[regName]]
+
+  if (regName == "WORLD") {
+    actualRegion <- NULL   # NULL -> alpha applied to all region rows
     displayName  <- "World"
+  } else if (regName == "EU27") {
+    actualRegion <- "EU27"
+    displayName  <- "EU27"
   } else {
-    actualRegion <- regName # Pass "DEU", "FRA", etc.
+    actualRegion <- regName
     displayName  <- regName
   }
 
-  message(sprintf("\n--- Optimizing %s (Target: %.4f Mt) ---", displayName, bg))
+  message(sprintf("\n--- Optimizing %s (Target: %.4f) ---", displayName, bg))
   skipRegion <- FALSE
-  
+
   tryCatch({
-  # A. Update GAMS File (Only needed for specific regions)
-  if (!is.null(actualRegion)) {
+  # Update fCountries in main.gms for single-region runs only.
+  # EU27 and WORLD require all regions to run, so main.gms is left unchanged.
+  if (!is.null(actualRegion) && actualRegion != "EU27") {
     configureGamsFile("main.gms", actualRegion)
   }
 
-  # B. Auto-Bracket
-  # Note: alpha is now a change factor. 0.0 = No change. 1.0 = +100% (Double price).
   brkt <- autoBracketFromSeed(
     seedAlpha    = 0.1,
     budgetTarget = bg,
@@ -539,7 +448,7 @@ for (regName in names(runQueue)) {
     targetYear   = selectedYear,
     minAlpha     = -0.5,           # Allow price reduction up to -50% if needed
     maxAlpha     = 10.0,           # Allow up to +1000% increase
-    expandFactor = 2.0,
+    expandFactor = 4.0,
     maxProbes    = 12,
     verbose      = TRUE
   )
@@ -565,29 +474,21 @@ for (regName in names(runQueue)) {
   finalAlpha <- solveResult$alpha
   message(sprintf(" -> Converged %s: Alpha=%.3f", displayName, finalAlpha))
 
-  # D. Update State & Backup
+  # Apply converged alpha and persist as the new baseline for subsequent regions
   currentEnvWide <- applyAlpha(currentEnvWide, yearCols, finalAlpha, actualRegion)
   fwrite(currentEnvWide, inputCsvPath, na = "NA")
   file.copy(inputCsvPath, backupCsvPath, overwrite = TRUE)
-  resultsLog[[regName]] <- list(status="OK", alpha=finalAlpha)
-}, error = function(e) {
-    
-    # --- FAILURE HANDLER ---
-    message(sprintf("  !! FAILURE for %s !!", displayName))
-    message(sprintf("  Error: %s", e$message))
-    message("  -> Reverting file to previous state and skipping...")
-    
-    # Revert 'iEnvPolicies.csv' to the last known good state (backupCsvPath)
-    if (file.exists(backupCsvPath)) {
-      file.copy(backupCsvPath, inputCsvPath, overwrite = TRUE)
-    }
-    
-    # Log the failure
+  resultsLog[[regName]] <- list(status = "OK", alpha = finalAlpha)
+
+  }, error = function(e) {
+    message(sprintf("  !! FAILURE for %s: %s", displayName, e$message))
+    message("  -> Reverting to last good state and skipping.")
+    if (file.exists(backupCsvPath)) file.copy(backupCsvPath, inputCsvPath, overwrite = TRUE)
     resultsLog[[regName]] <<- list(status = "FAILED", error = e$message)
     skipRegion <<- TRUE
   })
-  
-  if (skipRegion) next # Jump to the next country immediately
+
+  if (skipRegion) next
 }
 
 message("\n--- Final Summary ---")
@@ -599,10 +500,9 @@ for (r in names(resultsLog)) {
     message(sprintf(" [FAILED] %s : %s", r, item$error))
   }
 }
-# FINAL WRAP UP
+
 sink(type = "message")
 sink()
 
-# FINISH
 writeFinalPolicyFiles(currentEnvWide, yearCols, 0.0, NULL)
 message(sprintf("Done. Total time: %s", Sys.time() - start_time))

--- a/scripts/tasks/findCarbonPrice.R
+++ b/scripts/tasks/findCarbonPrice.R
@@ -18,7 +18,7 @@
 #    the tracked emissions variable, scaled to the unit of the budget targets.
 # 5) Iteratively adjust alpha until emissions meet the target using:
 #      • automatic bracketing around a seed alpha
-#      • bisection root-finding to converge to the target
+#      • regula falsi (false-position) root-finding, with bisection fallback on stall
 # 6) Repeat sequentially for each entry in `targetList`, carrying forward the
 #    updated policy file so each region builds on previously optimized prices.
 #
@@ -207,7 +207,7 @@ emissionsOPENPROM <- function(envWide, yearCols, alpha, targetRegion, targetYear
 }
 
 # ----------------------------
-# Seeding, bracketing, bisection solver
+# Seeding, bracketing, regula falsi solver
 # ----------------------------
 
 alphaSeedLinear <- function(alpha0, E0, alphar, Er, Etarget, warn = TRUE, stopIfOutside = FALSE) {
@@ -279,19 +279,25 @@ findAlphaForBudget <- function(envWide, yearCols, budgetTarget,
   aL <- lowerAlpha; aU <- upperAlpha
   emisL <- eLow;     emisU <- eHigh
   it <- 0
-  # Illinois flag: tracks which side was updated twice in a row so we can
-  # halve that side's emission value, keeping superlinear convergence guaranteed.
-  lastSide <- NA
+  prevAM <- NA
 
   while (it < maxIter) {
     it <- it + 1
 
-    # Illinois / false-position step: interpolate linearly toward the target.
-    # Much faster than bisection (superlinear convergence) because it uses the
-    # gradient information already available from the two bracket endpoints.
-    # Falls back to bisection midpoint if interpolation lands outside the bracket.
-    aM <- aL + (budgetTarget - emisL) * (aU - aL) / (emisU - emisL)
-    aM <- max(aL, min(aU, aM))   # clamp to bracket for safety
+    # False-position (regula falsi) step: linearly interpolate toward the target.
+    # Faster than bisection because it uses gradient information from both endpoints.
+    # If the interpolated point repeats the previous one (stall), fall back to the
+    # bisection midpoint to guarantee progress.
+    aM_interp <- aL + (budgetTarget - emisL) * (aU - aL) / (emisU - emisL)
+    aM_interp <- max(aL, min(aU, aM_interp))   # clamp to bracket
+
+    if (!is.na(prevAM) && abs(aM_interp - prevAM) / max(1.0, abs(aM_interp)) < 1e-6) {
+      aM <- 0.5 * (aL + aU)   # stall detected: bisection fallback
+      if (verbose) message(sprintf("Iter %02d: stall detected, using bisection midpoint", it))
+    } else {
+      aM <- aM_interp
+    }
+    prevAM <- aM
 
     emisM <- emissionsOPENPROM(envWide, yearCols, aM, targetRegion, targetYear)
     if (verbose) message(sprintf("Iter %02d: aM=%.6f -> E=%.6f (target=%.6f)", it, aM, emisM, budgetTarget))
@@ -303,13 +309,9 @@ findAlphaForBudget <- function(envWide, yearCols, budgetTarget,
     }
 
     if (emisM > budgetTarget) {
-      # Left side (high-emission) moves up
-      if (identical(lastSide, "L")) emisU <- emisU / 2   # Illinois correction
-      aL <- aM; emisL <- emisM; lastSide <- "L"
+      aL <- aM; emisL <- emisM
     } else {
-      # Right side (low-emission) moves down
-      if (identical(lastSide, "U")) emisL <- emisL / 2   # Illinois correction
-      aU <- aM; emisU <- emisM; lastSide <- "U"
+      aU <- aM; emisU <- emisM
     }
   }
 
@@ -465,7 +467,7 @@ for (regName in names(targetList)) {
     eLow         = brkt$EL,
     eHigh        = brkt$EU,
     tolAlphaRel  = 1e-2,
-    tolEmisAbs   = 1e-1,
+    tolEmisAbs   = 1e+1,
     maxIter      = 60,
     verbose      = TRUE,
     writeFinalCsv = FALSE

--- a/scripts/tasks/findCarbonPrice.R
+++ b/scripts/tasks/findCarbonPrice.R
@@ -178,7 +178,10 @@ emissionsOPENPROM <- function(envWide, yearCols, alpha, targetRegion, targetYear
 
   # Read GDX output and extract emissions via postprom
   regions <- readGDX(file.path(workDir, "blabla.gdx"), "runCYL")
-  years   <- paste0("y", c(2010:2020, as.character(readGDX(file.path(workDir, "blabla.gdx"), "an"))))
+  years <- as.character(readGDX(file.path(workDir, "blabla.gdx"), "datay"))
+  years <- c(years, as.character(readGDX(file.path(workDir, "blabla.gdx"), "an")))
+  years <- paste0("y", years)
+
   # Suppress console noise from reportEmissions
   utils::capture.output({
       suppressMessages({
@@ -304,8 +307,8 @@ findAlphaForBudget <- function(envWide, yearCols, budgetTarget,
 
     if (abs(emisM - budgetTarget) < tolEmisAbs || abs(aU - aL) / max(1.0, abs(aM)) < tolAlphaRel) {
       if (verbose) message("Converged.")
-      if (writeFinalCsv) writeFinalPolicyFiles(envWide, yearCols, aU, targetRegion)
-      return(list(alpha = aU, emissions = emisU, converged = TRUE, iters = it))
+      if (writeFinalCsv) writeFinalPolicyFiles(envWide, yearCols, aM, targetRegion)
+      return(list(alpha = aM, emissions = emisM, converged = TRUE, iters = it))
     }
 
     if (emisM > budgetTarget) {
@@ -336,9 +339,9 @@ extractEmissions <- function(dataMagpie) {
   # emissionsVariable: name of the variable in the reportEmissions magpie object
   # emissionsScale:    multiplier to convert to the same unit as the budget targets
   emissions <- dataMagpie[, , emissionsVariable] * emissionsScale
-  emissionsMt <- dimSums(emissions, dim = 3)
-  getNames(emissionsMt) <- emissionsVariable
-  emissionsMt
+  #emissionsMt <- dimSums(emissions, dim = 3)
+  #getNames(emissions) <- emissions
+  emissions
 }
 
 # ----------------------------
@@ -450,8 +453,8 @@ for (regName in names(targetList)) {
     targetYear   = selectedYear,
     minAlpha     = -0.5,           # Allow price reduction up to -50% if needed
     maxAlpha     = 10.0,           # Allow up to +1000% increase
-    expandFactor = 4.0,
-    maxProbes    = 12,
+    expandFactor = 3.0,
+    maxProbes    = 7,
     verbose      = TRUE
   )
 

--- a/scripts/tools/design_carbon_price.py
+++ b/scripts/tools/design_carbon_price.py
@@ -1,0 +1,452 @@
+"""
+Carbon Price Path Designer for iEnvPolicies.csv
+================================================
+Design carbon price paths and write them back to data/iEnvPolicies.csv.
+
+Usage examples
+--------------
+# Linear ramp from 25 in 2025 to 165 in 2040, flat thereafter, for all EU regions
+python scripts/design_carbon_price.py \
+    --policy exogCV_NPi \
+    --regions AUT BEL BGR CZE DEU DNK ESP EST FIN FRA GBR GRC HRV HUN IRL ITA LTU LUX LVA MLT NLD POL PRT ROU SVK SVN SWE \
+    --shape linear \
+    --anchor 2025 25 --anchor 2040 165 \
+    --flat-after 2040
+
+# Exponential growth for a custom scenario
+python scripts/design_carbon_price.py \
+    --policy exogCV_2C \
+    --regions DEU FRA \
+    --shape exponential \
+    --anchor 2025 30 --anchor 2050 200
+
+# Reach 165 by 2050, then grow 2.5% per year through 2100
+python scripts/design_carbon_price.py \
+    --policy exogCV_NPi \
+    --regions EU27 \
+    --shape linear \
+    --anchor 2025 84 --anchor 2050 165 \
+    --grow-after 2050 2.5
+
+# Preview without writing
+python scripts/design_carbon_price.py \
+    --policy exogCV_NPi \
+    --regions AUT \
+    --shape linear \
+    --anchor 2025 25 --anchor 2050 150 \
+    --preview
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+
+YEARS = list(range(2010, 2101))
+DATA_FILE = Path(__file__).parent.parent / "data" / "iEnvPolicies.csv"
+
+
+# ---------------------------------------------------------------------------
+# Path shapes
+# ---------------------------------------------------------------------------
+
+def _interp_linear(anchors: dict[int, float], flat_after: int | None) -> dict[int, float]:
+    """Piecewise-linear interpolation between anchor points."""
+    sorted_years = sorted(anchors)
+    result = {}
+    for y in YEARS:
+        if flat_after and y > flat_after:
+            result[y] = anchors.get(flat_after, anchors[sorted_years[-1]])
+            continue
+        if y <= sorted_years[0]:
+            result[y] = anchors[sorted_years[0]]
+        elif y >= sorted_years[-1]:
+            result[y] = anchors[sorted_years[-1]]
+        else:
+            for i in range(len(sorted_years) - 1):
+                y0, y1 = sorted_years[i], sorted_years[i + 1]
+                if y0 <= y <= y1:
+                    t = (y - y0) / (y1 - y0)
+                    result[y] = anchors[y0] + t * (anchors[y1] - anchors[y0])
+                    break
+    return result
+
+
+def _interp_exponential(anchors: dict[int, float], flat_after: int | None) -> dict[int, float]:
+    """Piecewise-exponential growth between anchor points."""
+    import math
+    sorted_years = sorted(anchors)
+    result = {}
+    for y in YEARS:
+        if flat_after and y > flat_after:
+            result[y] = anchors.get(flat_after, anchors[sorted_years[-1]])
+            continue
+        if y <= sorted_years[0]:
+            result[y] = anchors[sorted_years[0]]
+        elif y >= sorted_years[-1]:
+            result[y] = anchors[sorted_years[-1]]
+        else:
+            for i in range(len(sorted_years) - 1):
+                y0, y1 = sorted_years[i], sorted_years[i + 1]
+                if y0 <= y <= y1:
+                    v0, v1 = anchors[y0], anchors[y1]
+                    if v0 <= 0 or v1 <= 0:
+                        # Fall back to linear for zero/negative anchors
+                        t = (y - y0) / (y1 - y0)
+                        result[y] = v0 + t * (v1 - v0)
+                    else:
+                        t = (y - y0) / (y1 - y0)
+                        result[y] = v0 * math.exp(t * math.log(v1 / v0))
+                    break
+    return result
+
+
+def _interp_ssplike(anchors: dict[int, float], flat_after: int | None) -> dict[int, float]:
+    """S-curve (logistic) between anchor points — slow start, fast middle, plateau."""
+    import math
+    sorted_years = sorted(anchors)
+    result = {}
+    for y in YEARS:
+        if flat_after and y > flat_after:
+            result[y] = anchors.get(flat_after, anchors[sorted_years[-1]])
+            continue
+        if y <= sorted_years[0]:
+            result[y] = anchors[sorted_years[0]]
+        elif y >= sorted_years[-1]:
+            result[y] = anchors[sorted_years[-1]]
+        else:
+            for i in range(len(sorted_years) - 1):
+                y0, y1 = sorted_years[i], sorted_years[i + 1]
+                if y0 <= y <= y1:
+                    t = (y - y0) / (y1 - y0)
+                    # Smooth step (cubic S-curve)
+                    s = t * t * (3 - 2 * t)
+                    result[y] = anchors[y0] + s * (anchors[y1] - anchors[y0])
+                    break
+    return result
+
+
+def _interp_trajectory(anchors: dict[int, float], flat_after: int | None, alpha: float = 1.0) -> dict[int, float]:
+    """NDC→LTS trajectory: E(t) = E_NDC - (E_NDC - E_LTS) * ((t - t_NDC) / (t_LTS - t_NDC))^alpha.
+
+    Requires exactly two anchors: the NDC point and the LTS point.
+    alpha < 1 : concave  (fast early reduction, slows down)
+    alpha = 1 : linear
+    alpha > 1 : convex   (slow start, accelerates toward LTS)
+    """
+    if len(anchors) != 2:
+        raise ValueError("Shape 'trajectory' requires exactly two --anchor points: the NDC year/price and the LTS year/price.")
+    t_ndc, t_lts = sorted(anchors)
+    e_ndc, e_lts = anchors[t_ndc], anchors[t_lts]
+    span = t_lts - t_ndc
+    result = {}
+    for y in YEARS:
+        if y <= t_ndc:
+            result[y] = e_ndc
+        elif y >= t_lts:
+            result[y] = e_lts if not (flat_after and y > flat_after) else e_lts
+        else:
+            if flat_after and y > flat_after:
+                result[y] = anchors.get(flat_after, e_lts)
+            else:
+                t = (y - t_ndc) / span
+                result[y] = e_ndc - (e_ndc - e_lts) * (t ** alpha)
+    return result
+
+
+SHAPES = {
+    "linear": _interp_linear,
+    "exponential": _interp_exponential,
+    "scurve": _interp_ssplike,
+    "trajectory": _interp_trajectory,
+}
+
+
+# ---------------------------------------------------------------------------
+# CSV read / write
+# ---------------------------------------------------------------------------
+
+def read_csv(path: Path) -> tuple[list[str], list[list[str]]]:
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        rows = list(reader)
+    return header, rows
+
+
+def write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def find_year_col(header: list[str], year: int) -> int:
+    try:
+        return header.index(str(year))
+    except ValueError:
+        raise ValueError(f"Year {year} not found in CSV header.")
+
+
+# ---------------------------------------------------------------------------
+# Main logic
+# ---------------------------------------------------------------------------
+
+def apply_growth_tail(path: dict[int, float], from_year: int, annual_rate_pct: float) -> dict[int, float]:
+    """Compound the price by annual_rate_pct % every year starting from from_year+1."""
+    rate = annual_rate_pct / 100.0
+    if from_year not in path:
+        raise ValueError(f"--grow-after year {from_year} is not in the computed path.")
+    base = path[from_year]
+    for y in YEARS:
+        if y > from_year:
+            base = base * (1 + rate)
+            path[y] = base
+    return path
+
+
+def build_path(shape: str, anchors: dict[int, float], flat_after: int | None, alpha: float = 1.0) -> dict[int, float]:
+    if shape not in SHAPES:
+        raise ValueError(f"Unknown shape '{shape}'. Choose from: {', '.join(SHAPES)}")
+    if shape == "trajectory":
+        return _interp_trajectory(anchors, flat_after, alpha)
+    return SHAPES[shape](anchors, flat_after)
+
+
+def read_existing_path(
+    header: list[str],
+    rows: list[list[str]],
+    policy: str,
+    region: str,
+) -> dict[int, float]:
+    """Read current year→price values for a single region/policy row from the CSV."""
+    for row in rows:
+        if row[0] == region and row[1] == policy:
+            result = {}
+            for y in YEARS:
+                col = find_year_col(header, y)
+                val = row[col]
+                result[y] = float(val) if val not in ("NA", "", "na") else 0.0
+            return result
+    raise ValueError(f"No row found for region={region}, policy={policy} in CSV.")
+
+
+def apply_path(
+    header: list[str],
+    rows: list[list[str]],
+    policy: str,
+    regions: list[str],
+    path: dict[int, float],
+    from_year: int | None = None,
+) -> tuple[list[list[str]], list[str]]:
+    updated = []
+    for region in regions:
+        matched = False
+        for row in rows:
+            if row[0] == region and row[1] == policy:
+                matched = True
+                for year, value in path.items():
+                    if from_year is not None and year < from_year:
+                        continue
+                    col = find_year_col(header, year)
+                    row[col] = str(round(value, 6))
+                updated.append(f"{region},{policy}")
+                break
+        if not matched:
+            print(f"  WARNING: no row found for region={region}, policy={policy} — skipping.", file=sys.stderr)
+    return rows, updated
+
+
+def preview_path(regions: list[str], policy: str, path: dict[int, float], milestone_years: list[int] | None = None) -> None:
+    if milestone_years is None:
+        milestone_years = [2025, 2030, 2035, 2040, 2045, 2050, 2060, 2070, 2080, 2090, 2100]
+    milestone_years = sorted(set(y for y in milestone_years if y in path))
+    print(f"\nPolicy: {policy}  |  Regions: {', '.join(regions)}")
+    print("-" * (14 * len(milestone_years) + 4))
+    print("  Year  |  " + "  ".join(f"{y:>8}" for y in milestone_years))
+    print("  Price |  " + "  ".join(f"{path[y]:>8.2f}" for y in milestone_years))
+    print("-" * (14 * len(milestone_years) + 4))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Design carbon price paths and update iEnvPolicies.csv",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--policy", required=True,
+        choices=["exogCV_NPi", "exogCV_Calib", "exogCV_1_5C", "exogCV_2C"],
+        help="Policy row to update (e.g. exogCV_NPi)",
+    )
+    p.add_argument(
+        "--regions", nargs="+", required=True,
+        help="Space-separated region codes (e.g. AUT BEL DEU), 'ALL' for every region, or 'EU27' for all 27 EU member states",
+    )
+    p.add_argument(
+        "--shape", default="linear", choices=list(SHAPES),
+        help="Interpolation shape between anchor points (default: linear)",
+    )
+    p.add_argument(
+        "--anchor", nargs=2, action="append", metavar=("YEAR", "PRICE"),
+        default=None,
+        help="year/price anchor pair; repeat for multiple anchors (e.g. --anchor 2025 25 --anchor 2050 150). "
+             "Optional when --grow-after is used alone — the script reads existing CSV values as the base.",
+    )
+    p.add_argument(
+        "--flat-after", type=int, default=None, metavar="YEAR",
+        help="Hold the price flat at the last anchor value after this year",
+    )
+    p.add_argument(
+        "--alpha", type=float, default=1.0,
+        help="Shape exponent for --shape trajectory. "
+             "α<1 concave (fast early, slows later), α=1 linear, α>1 convex (slow start, accelerates). "
+             "Suggested values: {0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.5, 2, 3}. Ignored for other shapes.",
+    )
+    p.add_argument(
+        "--grow-after", nargs=2, default=None, metavar=("YEAR", "RATE_PCT"),
+        help="After YEAR, compound the price by RATE_PCT %% per year through 2100 "
+             "(e.g. --grow-after 2050 2.5 raises price 2.5%% annually from 2051 onward). "
+             "Cannot be combined with --flat-after.",
+    )
+    p.add_argument(
+        "--preview", action="store_true",
+        help="Print a preview table but do NOT modify the CSV",
+    )
+    p.add_argument(
+        "--csv", default=str(DATA_FILE),
+        help=f"Path to iEnvPolicies.csv (default: {DATA_FILE})",
+    )
+    return p.parse_args(argv)
+
+
+ALL_REGIONS = [
+    "LAM", "OAS", "SSA", "NEU", "MEA", "REF", "CAZ",
+    "AUT", "BEL", "BGR", "CHA", "CYP", "CZE", "DEU", "DNK", "ESP", "EST",
+    "FIN", "FRA", "GBR", "GRC", "HRV", "HUN", "IND", "IRL", "ITA", "JPN",
+    "LTU", "LUX", "LVA", "MLT", "NLD", "POL", "PRT", "ROU", "SVK", "SVN",
+    "SWE", "USA",
+]
+
+EU27_REGIONS = [
+    "AUT", "BEL", "BGR", "CYP", "CZE", "DEU", "DNK", "ESP", "EST",
+    "FIN", "FRA", "GRC", "HRV", "HUN", "IRL", "ITA", "LTU", "LUX",
+    "LVA", "MLT", "NLD", "POL", "PRT", "ROU", "SVK", "SVN", "SWE",
+]
+
+REGION_GROUPS = {
+    "ALL": ALL_REGIONS,
+    "EU27": EU27_REGIONS,
+}
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    regions = []
+    for token in args.regions:
+        if token in REGION_GROUPS:
+            regions.extend(REGION_GROUPS[token])
+        else:
+            regions.append(token)
+    regions = list(dict.fromkeys(regions))  # deduplicate, preserve order
+
+    # Validate --grow-after
+    grow_after = None
+    if args.grow_after is not None:
+        if args.flat_after is not None:
+            print("ERROR: --grow-after and --flat-after are mutually exclusive.", file=sys.stderr)
+            sys.exit(1)
+        try:
+            grow_after = (int(args.grow_after[0]), float(args.grow_after[1]))
+        except ValueError:
+            print("ERROR: --grow-after expects an integer year and a numeric rate (e.g. --grow-after 2035 2).", file=sys.stderr)
+            sys.exit(1)
+
+    # Require --anchor unless grow-after-only mode
+    grow_only = (args.anchor is None and grow_after is not None)
+    if not grow_only and args.anchor is None:
+        print("ERROR: --anchor is required unless --grow-after is used alone.", file=sys.stderr)
+        sys.exit(1)
+
+    csv_path = Path(args.csv)
+    if not csv_path.exists():
+        print(f"ERROR: CSV file not found: {csv_path}", file=sys.stderr)
+        sys.exit(1)
+
+    header, rows = read_csv(csv_path)
+
+    if grow_only:
+        # Apply compound growth independently per region, starting from existing CSV values
+        gy, rate = grow_after
+        milestone_years = [gy, 2030, 2040, 2050, 2060, 2070, 2080, 2090, 2100]
+        all_updated = []
+        for region in regions:
+            try:
+                path = read_existing_path(header, rows, args.policy, region)
+            except ValueError as e:
+                print(f"  WARNING: {e} — skipping.", file=sys.stderr)
+                continue
+            path = apply_growth_tail(path, gy, rate)
+            if args.preview:
+                preview_path([region], args.policy, path, milestone_years=milestone_years)
+            else:
+                rows, updated = apply_path(header, rows, args.policy, [region], path, from_year=gy)
+                all_updated.extend(updated)
+        if args.preview:
+            print("\n[Preview only — CSV not modified]")
+        else:
+            write_csv(csv_path, header, rows)
+            print(f"\nUpdated {len(all_updated)} row(s) in {csv_path}:")
+            for r in all_updated:
+                print(f"  {r}")
+            print("Done.")
+    else:
+        # Normal mode: build path from anchors, apply to all regions uniformly
+        anchors = {}
+        for year_str, price_str in args.anchor:
+            try:
+                y, v = int(year_str), float(price_str)
+            except ValueError:
+                print(f"ERROR: invalid anchor '{year_str} {price_str}' — expected integer year and numeric price.", file=sys.stderr)
+                sys.exit(1)
+            if y not in YEARS:
+                print(f"ERROR: year {y} out of range {YEARS[0]}–{YEARS[-1]}.", file=sys.stderr)
+                sys.exit(1)
+            anchors[y] = v
+
+        if len(anchors) < 2:
+            print("ERROR: at least two --anchor points are required.", file=sys.stderr)
+            sys.exit(1)
+
+        if args.alpha != 1.0 and args.shape != "trajectory":
+            print(f"  WARNING: --alpha is only used with --shape trajectory; ignored for '{args.shape}'.", file=sys.stderr)
+
+        path = build_path(args.shape, anchors, args.flat_after, alpha=args.alpha)
+
+        if grow_after is not None:
+            path = apply_growth_tail(path, grow_after[0], grow_after[1])
+
+        milestone_years = sorted(anchors) + [2030, 2040, 2050, 2060, 2070, 2080, 2090, 2100]
+        if grow_after:
+            milestone_years.append(grow_after[0])
+        preview_path(regions, args.policy, path, milestone_years=milestone_years)
+
+        if args.preview:
+            print("\n[Preview only — CSV not modified]")
+            return
+
+        rows, updated = apply_path(header, rows, args.policy, regions, path, from_year=min(anchors))
+        write_csv(csv_path, header, rows)
+        print(f"\nUpdated {len(updated)} row(s) in {csv_path}:")
+        for r in updated:
+            print(f"  {r}")
+        print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/design_carbon_price.py
+++ b/scripts/tools/design_carbon_price.py
@@ -35,6 +35,15 @@ python scripts/design_carbon_price.py \
     --shape linear \
     --anchor 2025 25 --anchor 2050 150 \
     --preview
+
+# Shape trajectory (NDC→LTS) with alpha=0.5 (concave)
+python scripts/design_carbon_price.py \
+    --policy exogCV_NPi \
+    --regions AUT \
+    --shape trajectory  \
+    --anchor 2025 25 --anchor 2050 70 \
+    --alpha 0.1 \
+    --grow-after 2050 1
 """
 
 import argparse

--- a/scripts/tools/design_carbon_price.py
+++ b/scripts/tools/design_carbon_price.py
@@ -44,7 +44,7 @@ from pathlib import Path
 
 
 YEARS = list(range(2010, 2101))
-DATA_FILE = Path(__file__).parent.parent / "data" / "iEnvPolicies.csv"
+DATA_FILE = Path(__file__).parent.parent.parent / "data" / "iEnvPolicies.csv"
 
 
 # ---------------------------------------------------------------------------
@@ -240,6 +240,8 @@ def apply_path(
     path: dict[int, float],
     from_year: int | None = None,
 ) -> tuple[list[list[str]], list[str]]:
+    """Write path values into rows in-place. Years before from_year are left untouched,
+    preserving any existing historical values in the CSV for those years."""
     updated = []
     for region in regions:
         matched = False
@@ -381,7 +383,8 @@ def main(argv=None):
     header, rows = read_csv(csv_path)
 
     if grow_only:
-        # Apply compound growth independently per region, starting from existing CSV values
+        # grow-after-only mode: no --anchor provided, so the base price is read directly from
+        # the existing CSV for each region individually, then compounded forward from gy onward.
         gy, rate = grow_after
         milestone_years = [gy, 2030, 2040, 2050, 2060, 2070, 2080, 2090, 2100]
         all_updated = []
@@ -420,6 +423,8 @@ def main(argv=None):
             anchors[y] = v
 
         if len(anchors) < 2:
+            # trajectory enforces this inside _interp_trajectory with a clearer message;
+            # all other shapes need at least two points to define a segment.
             print("ERROR: at least two --anchor points are required.", file=sys.stderr)
             sys.exit(1)
 

--- a/scripts/tools/extractCumulatedEmissions.R
+++ b/scripts/tools/extractCumulatedEmissions.R
@@ -1,0 +1,125 @@
+# ============================================================
+# Extract a variable (default: Emissions|CO2|Cumulated) from a reporting.mif
+# ============================================================
+#
+# Reads a reporting.mif, filters to a chosen variable, a set of regions, and a
+# single year or a range of years, and prints a Region x Year table to the
+# terminal. Optionally also writes the result to a CSV (long format).
+#
+# Usage (Rscript):
+#   Rscript scripts/tasks/extractCumulatedEmissions.R <mif> <years> <regions> <variable> <out>
+#
+#   <mif>      path to reporting.mif (default: latest runs/*/reporting.mif)
+#   <years>    "2100"  or  "2050:2100"  or  "2030,2050,2100"   (default: 2100)
+#   <regions>  comma-separated region codes, or "ALL"          (default: ALL)
+#   <variable> variable to select (default: Emissions|CO2|Cumulated)
+#   <out>      optional csv path; if omitted, only prints to terminal
+#
+# Or source() this file and call extractVariableFromMif() directly.
+
+suppressPackageStartupMessages({
+  library(data.table)
+})
+
+# Find the most recently modified runs/*/reporting.mif.
+latestReportingMif <- function(runsDir = "runs") {
+  mifs <- list.files(runsDir, pattern = "^reporting\\.mif$",
+                     recursive = TRUE, full.names = TRUE)
+  if (!length(mifs)) stop("No reporting.mif found under ", runsDir)
+  mifs[which.max(file.info(mifs)$mtime)]
+}
+
+# Parse "2100", "2050:2100", or "2030,2050,2100" into an integer vector.
+parseYears <- function(spec) {
+  spec <- trimws(as.character(spec))
+  if (grepl(":", spec, fixed = TRUE)) {
+    bounds <- as.integer(strsplit(spec, ":", fixed = TRUE)[[1]])
+    return(seq(bounds[1], bounds[2]))
+  }
+  as.integer(trimws(strsplit(spec, ",", fixed = TRUE)[[1]]))
+}
+
+extractVariableFromMif <- function(mifPath,
+                                   years    = 2100,
+                                   regions  = "ALL",
+                                   variable = "Emissions|CO2|Cumulated",
+                                   outPath  = NULL) {
+  if (!file.exists(mifPath)) stop("MIF not found: ", mifPath)
+
+  # MIF is ';'-separated; a trailing ';' produces an empty final column we drop.
+  dt <- data.table::fread(mifPath, sep = ";", header = TRUE, check.names = FALSE)
+  emptyCols <- names(dt)[names(dt) == "" | grepl("^V[0-9]+$", names(dt))]
+  if (length(emptyCols)) dt[, (emptyCols) := NULL]
+
+  metaCols <- c("Model", "Scenario", "Region", "Variable", "Unit")
+  if (!all(metaCols %in% names(dt))) {
+    stop("Unexpected MIF header. Expected columns: ", paste(metaCols, collapse = ", "))
+  }
+
+  # Filter to the requested variable.
+  sub <- dt[Variable == variable]
+  if (!nrow(sub)) stop("Variable not found in MIF: ", variable)
+
+  # Filter regions (skip if "ALL").
+  if (!(length(regions) == 1 && toupper(regions[1]) == "ALL")) {
+    missing <- setdiff(regions, unique(sub$Region))
+    if (length(missing)) warning("Regions not found and skipped: ", paste(missing, collapse = ", "))
+    sub <- sub[Region %in% regions]
+    if (!nrow(sub)) stop("No rows after region filter.")
+  }
+
+  # Keep only requested year columns that actually exist.
+  yearWanted <- as.character(parseYears(years))
+  yearCols   <- intersect(yearWanted, names(sub))
+  missingYrs <- setdiff(yearWanted, yearCols)
+  if (length(missingYrs)) warning("Years not in MIF and skipped: ", paste(missingYrs, collapse = ", "))
+  if (!length(yearCols)) stop("None of the requested years are present in the MIF.")
+
+  keep <- c("Model", "Scenario", "Region", "Variable", "Unit", yearCols)
+  sub  <- sub[, ..keep]
+
+  # Long format: one row per region x year.
+  long <- data.table::melt(
+    sub,
+    id.vars       = c("Model", "Scenario", "Region", "Variable", "Unit"),
+    measure.vars  = yearCols,
+    variable.name = "Year",
+    value.name    = "Value"
+  )
+  long[, Year := as.integer(as.character(Year))]
+  data.table::setorder(long, Region, Year)
+
+  # Pretty terminal print: Region rows, Year columns.
+  wide <- data.table::dcast(long, Region ~ Year, value.var = "Value")
+  cat(sprintf("\n%s  [%s]\n", variable, unique(sub$Unit)[1]))
+  print(wide, row.names = FALSE)
+  cat("\n")
+
+  # Write CSV only if an output path was requested.
+  if (!is.null(outPath)) {
+    data.table::fwrite(long, outPath)
+    message(sprintf("Wrote %d rows to %s", nrow(long), outPath))
+  }
+  invisible(long)
+}
+
+# ----------------------------
+# Command-line entry point
+# ----------------------------
+if (sys.nframe() == 0) {
+  args     <- commandArgs(trailingOnly = TRUE)
+  mifPath  <- if (length(args) >= 1 && nzchar(args[1])) args[1] else latestReportingMif()
+  message("Using MIF: ", mifPath)
+  years    <- if (length(args) >= 2 && nzchar(args[2])) args[2] else 2100
+  regions  <- if (length(args) >= 3 && nzchar(args[3])) trimws(strsplit(args[3], ",")[[1]]) else "ALL"
+  variable <- if (length(args) >= 4 && nzchar(args[4])) args[4] else "Emissions|CO2|Cumulated"
+  outPath  <- if (length(args) >= 5 && nzchar(args[5])) args[5] else NULL
+
+  invisible(extractVariableFromMif(
+    mifPath  = mifPath,
+    years    = years,
+    regions  = regions,
+    variable = variable,
+    outPath  = outPath
+  ))
+}


### PR DESCRIPTION
Changes:

1. The findCarbonPrice.R now it can run for all regions at once and you can select more easily which variable to check, e.g., Emissions|CO2|Cumulated etc. 
2. I changed the bisection method with a more advanced one and it reduces at half the iterations for finding the solution, only if OPEN-PROM can find one.
3. I created a python script that updates the iEnvPolicies.csv with custom paths for the carbon prices from a year to another. For example, you can have a linear path from 2025-2030, then do it concave until 2050 and finally keep either constant or grow with a percentage until 2100.